### PR TITLE
allow kwargs to serializer(...) + allow caller to pass serializer to load_samples/store_samples!

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,1 @@
-comment: on
+comment: off

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,1 +1,1 @@
-comment: off
+comment: on

--- a/examples/flac.jl
+++ b/examples/flac.jl
@@ -10,7 +10,7 @@ using Onda, Test, Random
 
 """
      FLAC(lpcm::LPCM; sample_rate, level=5)
-     FLAC(signal::Signal)
+     FLAC(signal::Signal; level=5)
 
 Return a `FLAC<:AbstractLPCMSerializer` instance that represents the
 FLAC format assumed for signal files with the ".flac" extension.
@@ -37,8 +37,8 @@ struct FLAC{S} <: Onda.AbstractLPCMSerializer
     end
 end
 
-FLAC(signal::Signal) = FLAC(LPCM(signal); sample_rate=signal.sample_rate,
-                            level=Onda.file_option(signal, :level, 5))
+FLAC(signal::Signal; kwargs...) = FLAC(LPCM(signal); sample_rate=signal.sample_rate,
+                                       kwargs...)
 
 Onda.register_file_extension_for_serializer(:flac, FLAC)
 

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -342,20 +342,24 @@ end
 ##### load/store
 #####
 
-function load_samples(file_path::AbstractString, signal::Signal)
-    return Samples(signal, true, deserialize_lpcm(read(file_path), serializer(signal)))
+function load_samples(file_path::AbstractString, signal::Signal;
+                      serializer=serializer(signal))
+    return Samples(signal, true, deserialize_lpcm(read(file_path), serializer))
 end
 
-function load_samples(file_path::AbstractString, signal::Signal, span::AbstractTimeSpan)
+function load_samples(file_path::AbstractString, signal::Signal, span::AbstractTimeSpan;
+                      serializer=serializer(signal))
     sample_range = index_from_time(signal.sample_rate, span)
     offset, n = first(sample_range) - 1, length(sample_range)
-    data = open(io -> deserialize_lpcm(io, serializer(signal), offset, n), file_path, "r")
+    data = open(io -> deserialize_lpcm(io, serializer, offset, n), file_path, "r")
     return Samples(signal, true, data)
 end
 
-function store_samples!(file_path::AbstractString, samples::Samples; overwrite::Bool=true)
+function store_samples!(file_path::AbstractString, samples::Samples;
+                        overwrite::Bool=true,
+                        serializer=serializer(samples.signal))
     overwrite || (isfile(file_path) && error("overwrite disabled but file path already exists: $(file_path)"))
     samples = encode(samples)
-    open(io -> serialize_lpcm(io, samples.data, serializer(samples.signal)), file_path, "w")
+    open(io -> serialize_lpcm(io, samples.data, serializer), file_path, "w")
     return file_path
 end

--- a/src/serialization.jl
+++ b/src/serialization.jl
@@ -33,15 +33,15 @@ function register_file_extension_for_serializer(extension::Symbol, T::Type{<:Abs
 end
 
 """
-    serializer(signal::Signal)
+    serializer(signal::Signal; kwargs...)
 
-Return `S(signal)` where `S` is the `AbstractLPCMSerializer` that corresponds
-to `signal.file_extension` (as determined by the serializer author via
-`register_file_extension_for_serializer`).
+Return `S(signal; kwargs...)` where `S` is the `AbstractLPCMSerializer` that
+corresponds to `signal.file_extension` (as determined by the serializer author
+via `register_file_extension_for_serializer`).
 
 See also: [`deserialize_lpcm`](@ref), [`serialize_lpcm`](@ref)
 """
-serializer(signal::Signal) = (FILE_EXTENSIONS[signal.file_extension])(signal)
+serializer(signal::Signal; kwargs...) = (FILE_EXTENSIONS[signal.file_extension])(signal; kwargs...)
 
 """
     deserialize_lpcm(bytes, serializer::AbstractLPCMSerializer)
@@ -187,7 +187,7 @@ end
 
 """
     LPCMZst(lpcm::LPCM; level=3)
-    LPCMZst(signal::Signal)
+    LPCMZst(signal::Signal; level=3)
 
 Return a `LPCMZst<:AbstractLPCMSerializer` instance that corresponds to
 Onda's default interleaved LPCM format compressed by `zstd`. This serializer
@@ -204,7 +204,7 @@ struct LPCMZst{S} <: AbstractLPCMSerializer
     LPCMZst(lpcm::LPCM{S}; level=3) where {S} = new{S}(lpcm, level)
 end
 
-LPCMZst(signal::Signal) = LPCMZst(LPCM(signal); level=file_option(signal, :level, 3))
+LPCMZst(signal::Signal; kwargs...) = LPCMZst(LPCM(signal); kwargs...)
 
 register_file_extension_for_serializer(Symbol("lpcm.zst"), LPCMZst)
 


### PR DESCRIPTION
This PR is a stepping stone towards resolving #5; it doesn't quite go all the way though, since `load_samples`/`store_samples!` aren't exported/documented API functions.

I mainly whipped up this PR to test if we get Codecov status reports 😛 