### PR TITLE
Use explicit errors rather than assertions

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -197,6 +197,7 @@ function store!(dataset::Dataset, uuid::UUID, name::Symbol,
     if haskey(recording.signals, name) && !overwrite
         throw(ArgumentError("$name already exists in $uuid and `overwrite` is `false`"))
     end
+    is_valid(signal) || throw(ArgumentError("signal in `samples` is invalid"))
     if !is_lower_snake_case_alphanumeric(string(name))
         throw(ArgumentError("$name is not lower snake case and alphanumeric"))
     end

--- a/src/timespans.jl
+++ b/src/timespans.jl
@@ -34,7 +34,7 @@ struct TimeSpan <: AbstractTimeSpan
     first::Nanosecond
     last::Nanosecond
     function TimeSpan(first::Nanosecond, last::Nanosecond)
-        @assert first <= last
+        first <= last || throw(ArgumentError("start of time span should precede end, got $first and $last"))
         return new(first, last)
     end
     TimeSpan(first, last) = TimeSpan(Nanosecond(first), Nanosecond(last))

--- a/test/timespans.jl
+++ b/test/timespans.jl
@@ -10,6 +10,7 @@ using Test, Onda, Dates
     @test shortest_timespan_containing((t,t,t)) == t
     @test duration(t) == Nanosecond(0)
     @test duration(first(t)) == first(t)
+    @test_throws ArgumentError TimeSpan(4, 2)
 end
 
 @testset "contains(::TimeSpan...)" begin


### PR DESCRIPTION
Ref https://github.com/jrevels/YASGuide/pull/17. I just ran into this: got an assertion about `first <= last` with no indication of what the values actually were.