### PR TITLE
Allow passing a UUID to `create_recording!`

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -116,18 +116,22 @@ end
 #####
 
 """
-    create_recording!(dataset::Dataset{C}, duration::Nanosecond, custom=nothing)
+    create_recording!(dataset::Dataset{C}, duration::Nanosecond,
+                      custom=nothing, uuid::UUID=uuid4())
 
 Create `uuid::UUID => recording::Recording` where `recording` is constructed
-via the provided `duration` and `custom` fields, add the pair to
-`dataset.recordings`, and return the pair.
+via the provided `duration` and `custom` arguments, `uuid` is the provided UUID
+(which is computed if not provided), add the pair to `dataset.recordings`, and
+return the pair.
 
 The `custom` argument is passed along to the `Recording{C}` constructor, such
 that `custom isa C` must hold true.
 """
 function create_recording!(dataset::Dataset{C}, duration::Nanosecond,
-                           custom=nothing) where {C}
-    uuid = uuid4()
+                           custom=nothing, uuid::UUID=uuid4()) where {C}
+    if haskey(dataset.recordings, uuid)
+        throw(ArgumentError("recording with UUID $uuid already exists in dataset"))
+    end
     recording = Recording{C}(duration, Dict{Symbol,Signal}(), Set{Annotation}(), custom)
     dataset.recordings[uuid] = recording
     mkpath(samples_path(dataset, uuid))

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -167,9 +167,8 @@ end
         @test_throws ArgumentError store!(dataset, uuid, :name_okay, samples; overwrite=false)
 
         other = Dataset(joinpath(root, "other.onda"); create=true)
-        other.recordings[uuid] = Recording{Any}(duration, Dict{Symbol,Signal}(),
-                                                Set{Annotation}(), nothing)
-        mkpath(samples_path(other, uuid))
+        create_recording!(other, duration, nothing, uuid)
+        @test_throws ArgumentError create_recording!(other, duration, nothing, uuid)
         store!(other, uuid, :cool_stuff, samples)
         @test_throws ErrorException merge!(dataset, other; only_recordings=false)
         @test_throws ArgumentError merge!(dataset, other; only_recordings=true)


### PR DESCRIPTION
It's handy to be able to create a recording based on a pre-computed UUID, like when converting data from another format which uses UUIDs to Onda. This change adds a `uuid` argument to `create_recording!` that defaults to `uuid4()`, and adds a check to ensure that the provided UUID does not already exist in the dataset. Tests are added/adjusted accordingly.