### PR TITLE
Ensure invalid `Annotation`s can't be constructed

### DIFF
--- a/src/recordings.jl
+++ b/src/recordings.jl
@@ -66,6 +66,11 @@ struct Annotation <: AbstractTimeSpan
     value::String
     start_nanosecond::Nanosecond
     stop_nanosecond::Nanosecond
+    function Annotation(key::AbstractString, value::AbstractString,
+                        start::Nanosecond, stop::Nanosecond)
+        _validate_timespan(start, stop)
+        return new(key, value, start, stop)
+    end
 end
 
 MsgPack.msgpack_type(::Type{Annotation}) = MsgPack.StructType()

--- a/src/timespans.jl
+++ b/src/timespans.jl
@@ -19,6 +19,13 @@ Base.first(t::Period) = convert(Nanosecond, t)
 
 Base.last(t::Period) = convert(Nanosecond, t)
 
+function _validate_timespan(first::Nanosecond, last::Nanosecond)
+    if first > last
+        throw(ArgumentError("start of time span should precede end, got $first and $last"))
+    end
+    return nothing
+end
+
 #####
 ##### `TimeSpan`
 #####
@@ -34,7 +41,7 @@ struct TimeSpan <: AbstractTimeSpan
     first::Nanosecond
     last::Nanosecond
     function TimeSpan(first::Nanosecond, last::Nanosecond)
-        first <= last || throw(ArgumentError("start of time span should precede end, got $first and $last"))
+        _validate_timespan(first, last)
         return new(first, last)
     end
     TimeSpan(first, last) = TimeSpan(Nanosecond(first), Nanosecond(last))

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -175,6 +175,8 @@ end
         store!(dataset, uuid, :name_okay, samples)
         @test_throws ArgumentError store!(dataset, uuid, :name_okay, samples; overwrite=false)
 
+        @test_throws ArgumentError Annotation("hi", "there", Nanosecond(20), Nanosecond(4))
+
         other = Dataset(joinpath(root, "other.onda"); create=true)
         create_recording!(other, duration, nothing, uuid)
         @test_throws ArgumentError create_recording!(other, duration, nothing, uuid)


### PR DESCRIPTION
For `TimeSpan` we check that the start precedes the end, but we don't do that for `Annotation`. Ideally this should be a required check for all `AbstractTimeSpan`s, but alas, there's not really a way to enforce that.

This would have saved me so much time. ;-;