### PR TITLE
Implement `merge!(datasets...; only_recordings=false)`

### DIFF
--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -70,12 +70,11 @@ content in `destination`, this function will throw an error. An error will also
 be thrown if this function encounters multiple recordings with the same UUID.
 
 If `only_recordings` is `true`, then only the `recordings` field of each `Dataset`
-is merged, such that no filesystem content is read or written.
-
-NOTE: This function is currently only implemented when `only_recordings = true`.
+is merged, such that no filesystem content is read or written. If `only_recordings`
+is `false`, the samples stored on the filesystem for each dataset are `mv`'d to
+the corresponding location in the destination.
 """
 function Base.merge!(destination::Dataset, datasets::Dataset...; only_recordings::Bool=false)
-    only_recordings || error("`merge!(datasets::Dataset...; only_recordings=false)` is not yet implemented")
     for dataset in datasets
         for uuid in keys(dataset.recordings)
             if haskey(destination.recordings, uuid)
@@ -83,6 +82,11 @@ function Base.merge!(destination::Dataset, datasets::Dataset...; only_recordings
             end
         end
         merge!(destination.recordings, dataset.recordings)
+        if !only_recordings
+            for uuid in keys(dataset.recordings)
+                mv(samples_path(dataset, uuid), samples_path(destination, uuid))
+            end
+        end
     end
     return destination
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -181,7 +181,13 @@ end
         create_recording!(other, duration, nothing, uuid)
         @test_throws ArgumentError create_recording!(other, duration, nothing, uuid)
         store!(other, uuid, :cool_stuff, samples)
-        @test_throws ErrorException merge!(dataset, other; only_recordings=false)
         @test_throws ArgumentError merge!(dataset, other; only_recordings=true)
+        delete!(other, uuid)
+        new_uuid, _ = create_recording!(other, duration)
+        store!(other, new_uuid, :cool_stuff, samples)
+        @test !isempty(readdir(samples_path(other, new_uuid)))
+        merge!(dataset, other; only_recordings=false)
+        @test !isempty(readdir(samples_path(dataset, new_uuid)))
+        @test isempty(readdir(samples_path(other, new_uuid)))
     end
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -188,6 +188,6 @@ end
         @test !isempty(readdir(samples_path(other, new_uuid)))
         merge!(dataset, other; only_recordings=false)
         @test !isempty(readdir(samples_path(dataset, new_uuid)))
-        @test isempty(readdir(samples_path(other, new_uuid)))
+        @test !isdir(samples_path(other, new_uuid))
     end
 end


### PR DESCRIPTION
This simply `mv`s the samples stored in each dataset to the corresponding location in the destination dataset. We may want to make it configurable whether samples are `cp`'d or `mv`'d but ¯\\\_(ツ)\_/¯