### PR TITLE
replace extension mapping mechanism for AbstractLPCMSerializer with one that works with precompilation

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -59,6 +59,7 @@ duration
 
 ```@docs
 AbstractLPCMSerializer
+Onda.serializer_constructor_for_file_extension
 serializer
 deserialize_lpcm
 serialize_lpcm

--- a/examples/flac.jl
+++ b/examples/flac.jl
@@ -40,7 +40,7 @@ end
 FLAC(signal::Signal; kwargs...) = FLAC(LPCM(signal); sample_rate=signal.sample_rate,
                                        kwargs...)
 
-Onda.register_file_extension_for_serializer(:flac, FLAC)
+Onda.serializer_constructor_for_file_extension(::Val{:flac}) = FLAC
 
 function flac_raw_specification_flags(serializer::FLAC{S}) where {S}
     return (level="--compression-level-$(serializer.level)",

--- a/test/serialization.jl
+++ b/test/serialization.jl
@@ -12,3 +12,6 @@ using Test, Onda, Random
     io = IOBuffer(); serialize_lpcm(io, samples, s); seekstart(io)
     @test take!(io) == bytes
 end
+
+@test_throws ArgumentError Onda.serializer_constructor_for_file_extension(Val(:extension))
+@test_throws ErrorException Onda.register_file_extension_for_serializer(:extension, LPCM)


### PR DESCRIPTION
note this is a technically a breaking change, but hopefully not much downstream code is defining new `AbstractLPCMSerializer` subtypes yet (if they were, it was probably already broken lol)

fixes #21, hopefully (@hannahilea can you test this out to ensure it works for your use case - it's kinda hard to test precompilation stuff as part of CI...we could but it's not worth the effort right now)