### PR TITLE
add time_from_index/index_from_time to docs

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -53,6 +53,8 @@ contains
 overlaps
 shortest_timespan_containing
 duration
+time_from_index
+index_from_time
 ```
 
 ## Serialization


### PR DESCRIPTION
this was supposed to be here, was an oversight that it wasn't