### PR TITLE
Allow CodecZstd 0.7, bump version to 0.8.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"
@@ -12,10 +12,10 @@ TranscodingStreams = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [compat]
+CodecZstd = "0.6, 0.7"
 MsgPack = "1.1"
-julia = "1.0"
-CodecZstd = "0.6"
 TranscodingStreams = "0.9"
+julia = "1.0"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"


### PR DESCRIPTION
CodecZstd 0.7.0 requires Julia 1.3 and accesses zstd via a JLL. See https://github.com/JuliaIO/CodecZstd.jl/pull/20 for more information.

In the interest of releasing a version of Onda that supports the new version of CodecZstd, this also bumps the patch version.