### PR TITLE
validation improvements 

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -18,12 +18,14 @@ load
 store!
 delete!
 save_recordings_file
+Onda.validate_on_construction
 ```
 
 ## Onda Metadata Objects
 
 ```@docs
 Signal
+validate_signal
 signal_from_template
 span
 sizeof_samples
@@ -37,6 +39,7 @@ annotate!
 
 ```@docs
 Samples
+validate_samples
 channel
 channel_count
 sample_count

--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -8,7 +8,19 @@ using CodecZstd
 const ONDA_FORMAT_VERSION = v"0.3"
 
 """
-TODO
+    Onda.validate_on_construction()
+
+If this function returns `true`, Onda objects will be validated upon construction
+for compliance with the Onda specification.
+
+If this function returns `false`, no such validation will be performed upon construction.
+
+Users may interactively redefine this method in order to attempt to read malformed
+Onda datasets.
+
+Returns `true` by default.
+
+See also: [`validate_signal`](@ref), [`validate_samples`](@ref)
 """
 validate_on_construction() = true
 

--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -7,6 +7,11 @@ using CodecZstd
 
 const ONDA_FORMAT_VERSION = v"0.3"
 
+"""
+TODO
+"""
+validate_on_construction() = true
+
 #####
 ##### utilities
 #####
@@ -56,15 +61,16 @@ export AbstractTimeSpan, TimeSpan, contains, overlaps, shortest_timespan_contain
        index_from_time, time_from_index, duration
 
 include("recordings.jl")
-export Recording, Signal, signal_from_template, Annotation, annotate!, span,
-       sizeof_samples
+export Recording, Signal, validate_signal, signal_from_template, Annotation, annotate!,
+       span, sizeof_samples
 
 include("serialization.jl")
 export AbstractLPCMSerializer, serializer, deserialize_lpcm, serialize_lpcm,
        LPCM, LPCMZst
 
 include("samples.jl")
-export Samples, encode, encode!, decode, decode!, channel, channel_count, sample_count
+export Samples, validate_samples, encode, encode!, decode, decode!, channel,
+       channel_count, sample_count
 
 include("dataset.jl")
 export Dataset, samples_path, create_recording!, set_span!, load, store!, delete!,

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -186,10 +186,12 @@ function store!(dataset::Dataset, uuid::UUID, name::Symbol,
     if haskey(recording.signals, name) && !overwrite
         throw(ArgumentError("$name already exists in $uuid and `overwrite` is `false`"))
     end
-    is_valid(signal) || throw(ArgumentError("signal in `samples` is invalid"))
     if !is_lower_snake_case_alphanumeric(string(name))
         throw(ArgumentError("$name is not lower snake case and alphanumeric"))
     end
+    validate_signal(signal)
+    validate_samples(samples)
+    duration(signal) == duration(samples) || throw(ArgumentError("duration of `Samples` data does not match `Signal` duration"))
     recording.signals[name] = signal
     store_samples!(samples_path(dataset, uuid, name, signal.file_extension),
                    samples; overwrite=overwrite)

--- a/src/recordings.jl
+++ b/src/recordings.jl
@@ -31,7 +31,7 @@ function julia_type_from_onda_sample_type(t::AbstractString)
     t == "uint16" && return UInt16
     t == "uint32" && return UInt32
     t == "uint64" && return UInt64
-    error("sample type ", t, " is not supported by Onda")
+    throw(ArgumentError("sample type $t is not supported by Onda"))
 end
 
 function onda_sample_type_from_julia_type(T::Type)
@@ -43,7 +43,7 @@ function onda_sample_type_from_julia_type(T::Type)
     T === UInt16 && return "uint16"
     T === UInt32 && return "uint32"
     T === UInt64 && return "uint64"
-    error("sample type ", T, " is not supported by Onda")
+    throw(ArgumentError("sample type $T is not supported by Onda"))
 end
 
 #####

--- a/src/recordings.jl
+++ b/src/recordings.jl
@@ -115,11 +115,29 @@ Base.@kwdef struct Signal
     function Signal(channel_names, start_nanosecond, stop_nanosecond,
                     sample_unit, sample_resolution_in_unit, sample_offset_in_unit,
                     sample_type, sample_rate, file_extension, file_options)
-        _validate_timespan(start_nanosecond, stop_nanosecond)
-        return new(channel_names, start_nanosecond, stop_nanosecond,
-                   sample_unit, sample_resolution_in_unit, sample_offset_in_unit,
-                   sample_type, sample_rate, file_extension, file_options)
+        signal = new(channel_names, start_nanosecond, stop_nanosecond,
+                     sample_unit, sample_resolution_in_unit, sample_offset_in_unit,
+                     sample_type, sample_rate, file_extension, file_options)
+        validate_on_construction() && validate_signal(signal)
+        return signal
     end
+end
+
+is_valid_sample_type(T::Type) = onda_sample_type_from_julia_type(T) isa AbstractString
+is_valid_sample_unit(u) = is_lower_snake_case_alphanumeric(string(u))
+is_valid_channel_name(c) = is_lower_snake_case_alphanumeric(string(c), ('-', '.'))
+
+"""
+TODO
+"""
+function validate_signal(signal::Signal)
+    _validate_timespan(signal.start_nanosecond, signal.stop_nanosecond)
+    is_valid_sample_type(signal.sample_type) || throw(ArgumentError("invalid sample type: $(signal.sample_type)"))
+    is_valid_sample_unit(signal.sample_unit) || throw(ArgumentError("invalid sample unit: $(signal.sample_unit)"))
+    foreach(signal.channel_names) do c
+        is_valid_channel_name(c) || throw(ArgumentError("invalid channel name: $c"))
+    end
+    return nothing
 end
 
 function Base.:(==)(a::Signal, b::Signal)
@@ -127,12 +145,6 @@ function Base.:(==)(a::Signal, b::Signal)
 end
 
 MsgPack.msgpack_type(::Type{Signal}) = MsgPack.StructType()
-
-function is_valid(signal::Signal)
-    return is_lower_snake_case_alphanumeric(string(signal.sample_unit)) &&
-           all(n -> is_lower_snake_case_alphanumeric(string(n), ('-', '.')), signal.channel_names) &&
-           onda_sample_type_from_julia_type(signal.sample_type) isa AbstractString
-end
 
 function file_option(signal::Signal, name, default)
     signal.file_options isa Dict && return get(signal.file_options, name, default)

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -29,18 +29,27 @@ struct Samples{D<:AbstractMatrix}
     encoded::Bool
     data::D
     function Samples(signal::Signal, encoded::Bool, data::AbstractMatrix)
-        n_channels = channel_count(signal)
-        n_rows = size(data, 1)
-        if n_channels != n_rows
-            throw(DimensionMismatch("number of channels in signal ($n_channels) " *
-                                    "does not match number of rows in data matrix " *
-                                    "($n_rows)"))
-        end
-        if encoded && !(eltype(data) <: signal.sample_type)
-            throw(ArgumentError("signal and encoded data matrix have mismatched element types"))
-        end
-        return new{typeof(data)}(signal, encoded, data)
+        samples = new{typeof(data)}(signal, encoded, data)
+        validate_on_construction() && validate_samples(samples)
+        return samples
     end
+end
+
+"""
+TODO
+"""
+function validate_samples(samples::Samples)
+    n_channels = channel_count(samples.signal)
+    n_rows = size(samples.data, 1)
+    if n_channels != n_rows
+        throw(DimensionMismatch("number of channels in signal ($n_channels) " *
+                                "does not match number of rows in data matrix " *
+                                "($n_rows)"))
+    end
+    if samples.encoded && !(eltype(samples.data) <: samples.signal.sample_type)
+        throw(ArgumentError("signal and encoded data matrix have mismatched element types"))
+    end
+    return nothing
 end
 
 for f in (:getindex, :view)

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -54,9 +54,9 @@ function validate_samples(samples::Samples)
     n_channels = channel_count(samples.signal)
     n_rows = size(samples.data, 1)
     if n_channels != n_rows
-        throw(DimensionMismatch("number of channels in signal ($n_channels) " *
-                                "does not match number of rows in data matrix " *
-                                "($n_rows)"))
+        throw(ArgumentError("number of channels in signal ($n_channels) " *
+                            "does not match number of rows in data matrix " *
+                            "($n_rows)"))
     end
     if samples.encoded && !(eltype(samples.data) <: samples.signal.sample_type)
         throw(ArgumentError("signal and encoded data matrix have mismatched element types"))

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -22,6 +22,9 @@ indices, but also accept channel names for row indices and [`TimeSpan`](@ref)
 values for column indices; see `Onda/examples/tour.jl` for a comprehensive
 set of indexing examples.
 
+If [`validate_on_construction`](@ref) returns `true`, [`validate_samples`](@ref)
+is called on all new `Samples` instances upon construction.
+
 See also: [`encode`](@ref), [`encode!`](@ref), [`decode`](@ref), [`decode!`](@ref)
 """
 struct Samples{D<:AbstractMatrix}
@@ -36,7 +39,16 @@ struct Samples{D<:AbstractMatrix}
 end
 
 """
-TODO
+    validate_samples(samples::Samples)
+
+Returns `nothing`, checking that the given `samples` are valid w.r.t. the
+underlying `samples.signal` and the Onda specification's canonical LPCM
+representation. If a violation is found, an `ArgumentError` is thrown.
+
+Properties that are validated by this function include:
+
+- encoded element type matches `samples.signal.sample_type`
+- the number of rows of `samples.data` matches the number of channels in `samples.signal`
 """
 function validate_samples(samples::Samples)
     n_channels = channel_count(samples.signal)

--- a/src/timespans.jl
+++ b/src/timespans.jl
@@ -19,7 +19,7 @@ Base.first(t::Period) = convert(Nanosecond, t)
 
 Base.last(t::Period) = convert(Nanosecond, t)
 
-function _validate_timespan(first::Nanosecond, last::Nanosecond)
+function validate_timespan(first::Nanosecond, last::Nanosecond)
     if first > last
         throw(ArgumentError("start of time span should precede end, got $first and $last"))
     end
@@ -41,7 +41,7 @@ struct TimeSpan <: AbstractTimeSpan
     first::Nanosecond
     last::Nanosecond
     function TimeSpan(first::Nanosecond, last::Nanosecond)
-        _validate_timespan(first, last)
+        validate_timespan(first, last)
         return new(first, last)
     end
     TimeSpan(first, last) = TimeSpan(Nanosecond(first), Nanosecond(last))

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -183,7 +183,7 @@ end
         dataset = Dataset(joinpath(root, "okay.onda"); create=true)
         uuid, recording = create_recording!(dataset)
         signal = Signal([:a], Nanosecond(0), Nanosecond(Second(10)), :mv, 0.25, 0.0, Int8, 100, Symbol("lpcm.zst"), nothing)
-        @test_throws DimensionMismatch Samples(signal, true, rand(Int8, 2, 10))
+        @test_throws ArgumentError Samples(signal, true, rand(Int8, 2, 10))
         @test_throws ArgumentError Samples(signal, true, rand(Float32, 1, 10))
         samples = Samples(signal, true, rand(Int8, 1, 10 * 100))
         @test_throws ArgumentError store!(dataset, uuid, Symbol("***HI***"), samples)
@@ -261,20 +261,28 @@ end
     @test_throws ArgumentError signal_from_template(signal; sample_unit=Symbol("Ha Ha"))
     @test_throws ArgumentError signal_from_template(signal; sample_type=Complex{Float64})
     @test_throws ArgumentError signal_from_template(signal; channel_names=[Symbol("Ha Ha")])
+    @test_throws ArgumentError Samples(signal, false, rand(4, 10))
+    @test_throws ArgumentError Samples(signal, true, rand(Int32, 3, 10))
 
     Onda.validate_on_construction() = false
     @test signal_from_template(signal; start_nanosecond=Nanosecond(12000)) isa Signal
     @test signal_from_template(signal; sample_unit=Symbol("Ha Ha")) isa Signal
     @test signal_from_template(signal; sample_type=Complex{Float64}) isa Signal
     @test signal_from_template(signal; channel_names=[Symbol("Ha Ha")]) isa Signal
+    @test Samples(signal, false, rand(4, 10)) isa Samples
+    @test Samples(signal, true, rand(Int32, 3, 10)) isa Samples
     @test_throws ArgumentError validate_signal(signal_from_template(signal; start_nanosecond=Nanosecond(12000)))
     @test_throws ArgumentError validate_signal(signal_from_template(signal; sample_unit=Symbol("Ha Ha")))
     @test_throws ArgumentError validate_signal(signal_from_template(signal; sample_type=Complex{Float64}))
     @test_throws ArgumentError validate_signal(signal_from_template(signal; channel_names=[Symbol("Ha Ha")]))
+    @test_throws ArgumentError validate_samples(Samples(signal, false, rand(4, 10)))
+    @test_throws ArgumentError validate_samples(Samples(signal, true, rand(Int32, 3, 10)))
 
     Onda.validate_on_construction() = true
     @test_throws ArgumentError signal_from_template(signal; start_nanosecond=Nanosecond(12000))
     @test_throws ArgumentError signal_from_template(signal; sample_unit=Symbol("Ha Ha"))
     @test_throws ArgumentError signal_from_template(signal; sample_type=Complex{Float64})
     @test_throws ArgumentError signal_from_template(signal; channel_names=[Symbol("Ha Ha")])
+    @test_throws ArgumentError Samples(signal, false, rand(4, 10))
+    @test_throws ArgumentError Samples(signal, true, rand(Int32, 3, 10))
 end

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -244,3 +244,37 @@ end
         end
     end
 end
+
+@testset "validate_on_construction" begin
+    signal = Signal(channel_names=[:a, :b, :c],
+                    start_nanosecond=Nanosecond(1000),
+                    stop_nanosecond=Nanosecond(11000),
+                    sample_unit=:microvolt,
+                    sample_resolution_in_unit=1.0,
+                    sample_offset_in_unit=0.0,
+                    sample_type=Int16,
+                    sample_rate=100.0,
+                    file_extension=:lpcm,
+                    file_options=nothing)
+    @test Onda.validate_on_construction()
+    @test_throws ArgumentError signal_from_template(signal; start_nanosecond=Nanosecond(12000))
+    @test_throws ArgumentError signal_from_template(signal; sample_unit=Symbol("Ha Ha"))
+    @test_throws ArgumentError signal_from_template(signal; sample_type=Complex{Float64})
+    @test_throws ArgumentError signal_from_template(signal; channel_names=[Symbol("Ha Ha")])
+
+    Onda.validate_on_construction() = false
+    @test signal_from_template(signal; start_nanosecond=Nanosecond(12000)) isa Signal
+    @test signal_from_template(signal; sample_unit=Symbol("Ha Ha")) isa Signal
+    @test signal_from_template(signal; sample_type=Complex{Float64}) isa Signal
+    @test signal_from_template(signal; channel_names=[Symbol("Ha Ha")]) isa Signal
+    @test_throws ArgumentError validate_signal(signal_from_template(signal; start_nanosecond=Nanosecond(12000)))
+    @test_throws ArgumentError validate_signal(signal_from_template(signal; sample_unit=Symbol("Ha Ha")))
+    @test_throws ArgumentError validate_signal(signal_from_template(signal; sample_type=Complex{Float64}))
+    @test_throws ArgumentError validate_signal(signal_from_template(signal; channel_names=[Symbol("Ha Ha")]))
+
+    Onda.validate_on_construction() = true
+    @test_throws ArgumentError signal_from_template(signal; start_nanosecond=Nanosecond(12000))
+    @test_throws ArgumentError signal_from_template(signal; sample_unit=Symbol("Ha Ha"))
+    @test_throws ArgumentError signal_from_template(signal; sample_type=Complex{Float64})
+    @test_throws ArgumentError signal_from_template(signal; channel_names=[Symbol("Ha Ha")])
+end


### PR DESCRIPTION
resolves #30, #33 

-  the previous on-`store!`-only Signal validation also occurs upon construction 
- the previous on-construction-only Samples validation also occurs upon `store!`
- allows users to toggle `validate_on_construction` so that you can still have a chance at reading malformed datasets (but `validate_on_construction` is `true` by default)
- validates that Samples/Signal durations match upon `store!`

still needs tests/docs