### PR TITLE
add warning to memory-leaky zstd-based deserialization method

### DIFF
--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -45,7 +45,19 @@ end
 
 zstd_decompress(bytes::Vector{UInt8}) = transcode(ZstdDecompressor, bytes)
 
-zstd_decompress(reader, io::IO) = reader(ZstdDecompressorStream(io))
+function zstd_decompress(reader, io::IO)
+    @warn """
+          Streaming `zstd` decompression via `Onda.zstd_decompress(reader, io::IO)` has been shown
+          to exhibit memory-leak-like  behaviors (underlying cause at time of writing is currently
+          unknown).
+
+          If you did not call this method directly, it's likely that this was reached via
+          a call to  `Onda.load(dataset, uuid, signal_name, span)`. This call may be replaced
+          with `Onda.load(dataset, uuid, signal_name)[:, span]`, but note that this will load
+          in *all* sample data for the given signal.
+          """
+    reader(ZstdDecompressorStream(io))
+end
 
 #####
 ##### includes/exports


### PR DESCRIPTION
@ararslan and I just spent about 7 hours reducing some upstream OOMs down to calls to this little devil. Specifically, our entrypoint to this was via `Onda.load(..., ::TimeSpan)` on some zstd-compressed signals. We don't have a good full MWE, but just calling it over and over ~100 times (for us, on ~1GB (decompressed) of data each call) should trigger it. 

When we first realized it was this, I was going to just delete this method, but I guess adding a warning is probably better for now (it's at least less breaking). Note that we're not sure what exactly causes the issue (maybe TranscodingStreams/CodecZstd streaming issue, or our usage of that package...?). Will file a corresponding issue to actually resolve this at some point, but that will require a good amount of debugging and isn't super high priority right now.

