### PR TITLE
Add method inadvertently removed in #41

### DIFF
--- a/src/timespans.jl
+++ b/src/timespans.jl
@@ -78,6 +78,8 @@ function contains(a::AbstractTimeSpan, b::AbstractTimeSpan)
     return first(a) <= first(b) && last(a) >= last(b)
 end
 
+contains(a::AbstractTimeSpan, b) = contains(a, TimeSpan(b))
+
 """
     overlaps(a, b)
 

--- a/test/timespans.jl
+++ b/test/timespans.jl
@@ -22,6 +22,7 @@ end
     @test !contains(TimeSpan(11, 20), TimeSpan(10, 19))
     @test !contains(TimeSpan(10, 19), TimeSpan(10, 21))
     @test !contains(TimeSpan(11, 19), TimeSpan(10, 20))
+    @test contains(TimeSpan(1, 10), Nanosecond(4))
 end
 
 @testset "overlaps(::TimeSpan...)" begin


### PR DESCRIPTION
Since we have type piracy on types from Dates to allow them to act like `TimeSpan`s, they could be used in `contains` until the signature was restricted to `AbstractTimeSpan`s in #41 to mitigate breakage from `contains` being reintroduced to Base.

I tried briefly to remove the type piracy, but there's a lot of `first`/`last` usage that would be annoying to work around.