### PR TITLE
Avoid dep warnings from non-deprecated function calls

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.9.0"
+version = "0.9.1"
 
 [deps]
 CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -110,7 +110,7 @@ is defined as `dataset.recordings[uuid].signals[signal_name].file_extension`.
 """
 function samples_path(dataset::Dataset, uuid::UUID, signal_name::Symbol)
     file_extension = dataset.recordings[uuid].signals[signal_name].file_extension
-    return samples_path(dataset, uuid, signal_name, file_extension)
+    return samples_path(dataset.path, uuid, signal_name, file_extension)
 end
 
 #####
@@ -132,7 +132,7 @@ See also: [`read_samples`](@ref), [`deserialize_lpcm`](@ref)
 """
 function load(dataset::Dataset, uuid::UUID, signal_name::Symbol, span::AbstractTimeSpan...)
     signal = dataset.recordings[uuid].signals[signal_name]
-    path = samples_path(dataset, uuid, signal_name, signal.file_extension)
+    path = samples_path(dataset.path, uuid, signal_name, signal.file_extension)
     return read_samples(path, signal, span...)
 end
 
@@ -184,7 +184,7 @@ function store!(dataset::Dataset, uuid::UUID, signal_name::Symbol,
     validate_samples(samples)
     duration(signal) == duration(samples) || throw(ArgumentError("duration of `Samples` data does not match `Signal` duration"))
     recording.signals[signal_name] = signal
-    write_samples(samples_path(dataset, uuid, signal_name, signal.file_extension), samples)
+    write_samples(samples_path(dataset.path, uuid, signal_name, signal.file_extension), samples)
     return recording
 end
 


### PR DESCRIPTION
I think these were missed in #47.