### PR TITLE
rename load to load_encoded, define load to decode Samples by default

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.10.2"
+version = "0.11.0"
 
 [deps]
 CodecZstd = "6b39b394-51ab-5f42-8807-6242bab2b4c2"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -39,6 +39,7 @@ annotate!
 
 ```@docs
 Samples
+==(::Samples, ::Samples)
 validate_samples
 channel
 channel_count

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,6 +13,7 @@ Note that Onda.jl's API follows a specific philosophy with respect to property a
 ```@docs
 Dataset
 load
+load_encoded
 save
 create_recording!
 store!

--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -34,7 +34,7 @@ export read_recordings_file, write_recordings_file, samples_path,
        read_samples, write_samples
 
 include("dataset.jl")
-export Dataset, create_recording!, load, save, store!, delete!
+export Dataset, create_recording!, load, load_encoded, save, store!, delete!
 
 include("printing.jl")
 

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -143,8 +143,8 @@ end
 """
     load_encoded(args...)
 
-Exactly the same as [`load`], but doesn't automatically call `decode` before
-returning the loaded `Samples`.
+Supports exactly the same methods as [`load`](@ref), but doesn't automatically call
+[`decode`](@ref) on the returned `Samples`.
 """
 function load_encoded(dataset::Dataset, uuid::UUID, signal_name::Symbol, span::AbstractTimeSpan...)
     signal = dataset.recordings[uuid].signals[signal_name]
@@ -164,7 +164,7 @@ end
 """
     load(dataset::Dataset, uuid::UUID, signal_name::Symbol[, span::AbstractTimeSpan])
 
-Load and return the decoded `Samples` object corresponding to the signal named
+Load, [`decode`](@ref), and return the `Samples` object corresponding to the signal named
 `signal_name` in the recording specified by `uuid`.
 
 If `span` is provided, this function returns the equivalent of
@@ -183,7 +183,11 @@ Return `Dict(signal_name => load(dataset, uuid, signal_name[, span]) for signal_
 
 See also: [`read_samples`](@ref), [`deserialize_lpcm`](@ref)
 """
-load(args...) = decode(load_encoded(args...))
+function load(args...)
+    result = load_encoded(args...)
+    result isa Dict && return Dict(k => decode(v) for (k, v) in result)
+    return result
+end
 
 #####
 ##### `store!`

--- a/src/dataset.jl
+++ b/src/dataset.jl
@@ -186,7 +186,7 @@ See also: [`read_samples`](@ref), [`deserialize_lpcm`](@ref)
 function load(args...)
     result = load_encoded(args...)
     result isa Dict && return Dict(k => decode(v) for (k, v) in result)
-    return result
+    return decode(result)
 end
 
 #####

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -40,6 +40,11 @@ struct Samples{D<:AbstractMatrix}
     end
 end
 
+"""
+    ==(a::Samples, b::Samples)
+
+Returns `a.encoded == b.encoded && a.signal == b.signal && a.data == b.data`.
+"""
 Base.:(==)(a::Samples, b::Samples) = a.encoded == b.encoded && a.signal == b.signal && a.data == b.data
 
 """

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -40,6 +40,8 @@ struct Samples{D<:AbstractMatrix}
     end
 end
 
+Base.:(==)(a::Samples, b::Samples) = a.encoded == b.encoded && a.signal == b.signal && a.data == b.data
+
 """
     validate_samples(samples::Samples)
 

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -118,6 +118,8 @@ using Test, Onda, Dates, MsgPack
         xs = load_encoded(dataset, uuid, (:x3, :x2))
         @test xs[:x3].signal == signals[:x3]
         @test xs[:x2].signal == signals[:x2]
+        @test decode(xs[:x3]) == load(dataset, uuid, :x3)
+        @test decode(xs[:x2]) == load(dataset, uuid, :x2)
         xs = load_encoded(dataset, uuid)
         span = TimeSpan(Second(1), Second(2))
         xs_span = load_encoded(dataset, uuid, span)

--- a/test/dataset.jl
+++ b/test/dataset.jl
@@ -112,14 +112,15 @@ using Test, Onda, Dates, MsgPack
         dataset = load(joinpath(root, "test"))
         @test length(dataset.recordings) == 1
         uuid, recording = first(dataset.recordings)
-        x1 = load(dataset, uuid, :x1)
+        x1 = load_encoded(dataset, uuid, :x1)
+        @test decode(x1) == load(dataset, uuid, :x1)
         @test x1.signal == signals[:x1]
-        xs = load(dataset, uuid, (:x3, :x2))
+        xs = load_encoded(dataset, uuid, (:x3, :x2))
         @test xs[:x3].signal == signals[:x3]
         @test xs[:x2].signal == signals[:x2]
-        xs = load(dataset, uuid)
+        xs = load_encoded(dataset, uuid)
         span = TimeSpan(Second(1), Second(2))
-        xs_span = load(dataset, uuid, span)
+        xs_span = load_encoded(dataset, uuid, span)
         for (name, s) in samples
             xi = xs[name]
             @test xi.signal == signals[name]
@@ -142,7 +143,7 @@ using Test, Onda, Dates, MsgPack
         delete!(dataset.recordings, uuid)
         uuid, recording = create_recording!(dataset)
         foreach(x -> annotate!(recording, x), old_recording.annotations)
-        foreach(x -> store!(dataset, uuid, x, load(old_dataset, old_uuid, x)), keys(old_recording.signals))
+        foreach(x -> store!(dataset, uuid, x, load_encoded(old_dataset, old_uuid, x)), keys(old_recording.signals))
         merge!(dataset, old_dataset, only_recordings=true)
         @test length(dataset.recordings) == 2
         r1 = dataset.recordings[old_uuid]
@@ -163,7 +164,7 @@ using Test, Onda, Dates, MsgPack
         r = dataset.recordings[uuid]
         original_signals_length = length(r.signals)
         signal_name, signal = first(r.signals)
-        signal_samples = load(dataset, uuid, signal_name)
+        signal_samples = load_encoded(dataset, uuid, signal_name)
         signal_samples_path = samples_path(dataset, uuid, signal_name)
         delete!(dataset, uuid, signal_name)
         @test r === dataset.recordings[uuid]


### PR DESCRIPTION
I actually don't have feelings on this either way, but opening as an RFC after @palday mentioned for many users:

> the idea of having to load and decode just adds mental overhead that they don't care about because of course you want to decode as soon as load. 

Can update tests/docs/examples/etc. if folks prefer this.