### PR TITLE
Allow indexing channel names by regex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.12.2"
+version = "0.12.3"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/examples/tour.jl
+++ b/examples/tour.jl
@@ -199,6 +199,11 @@ rows = ["f3", "c3", "p3"]
 rows = ["c3", 4, "f3"]
 @test eeg[rows, span].data == view(eeg, channel.(Ref(eeg), rows), span_range).data
 
+# One can also index rows by regular expressions. For example, to match all the
+# channels which have an `f`:
+f_channels = ["fp1", "f3","f7", "fz", "fp2", "f4", "f8"]
+@test eeg[r"f", span].data == view(eeg, channel.(Ref(eeg), f_channels), span_range).data
+
 # Note that `Samples` is not an `AbstractArray` subtype; the special indexing
 # behavior above is only defined for convenient data manipulation. It is fine
 # to access the sample data matrix directly via the `data` field if you need

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -22,9 +22,9 @@ If `validate` is `true`, [`Onda.validate`](@ref) is called on the constructed `S
 instance before it is returned.
 
 Note that `getindex` and `view` are defined on `Samples` to accept normal integer
-indices, but also accept channel names for row indices and `TimeSpan` values for
-column indices; see `Onda/examples/tour.jl` for a comprehensive set of indexing
-examples.
+indices, but also accept channel names or a regex to match channel names for row indices,
+and `TimeSpan` values for column indices; see `Onda/examples/tour.jl` for a comprehensive
+set of indexing examples.
 
 See also: [`load`](@ref), [`store`](@ref), [`encode`](@ref), [`encode!`](@ref), [`decode`](@ref), [`decode!`](@ref)
 """
@@ -133,6 +133,7 @@ row_arguments(samples::Samples, x) = _rangify(_row_arguments(samples, x))
 
 _row_arguments(samples::Samples, x) = _indices_fallback(_row_arguments, samples, x)
 _row_arguments(samples::Samples, name::AbstractString) = channel(samples, name)
+_row_arguments(samples::Samples, name::Regex) = findall(c -> match(name, c) !== nothing, samples.info.channels)
 
 column_arguments(samples::Samples, x) = _rangify(_column_arguments(samples, x))
 

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -92,13 +92,17 @@
             t = TimeSpans.time_from_index(s.info.sample_rate, i)
             t2 = TimeSpans.time_from_index(s.info.sample_rate, i + 15)
             j = TimeSpans.index_from_time(s.info.sample_rate, t2) - 1
-            for ch_inds in (:, 1:2, 2:3, 1:3, [3,1], [2,3,1], [1,2,3])
+            for (ch_inds, reg) in ((:, r""), (1:2, r"[ab]"), (2:3, r"[bc]"), (1:3, r"[abc]"), ([3,1], :skip), ([2,3,1], :skip), ([1,2,3], r"[abc]"))
                 @test s[chs[ch_inds], t].data == s[ch_inds, i].data
                 @test s[chs[ch_inds], TimeSpan(t, t2)].data == s.data[ch_inds, i:j]
                 @test s[chs[ch_inds], i:j].data == s.data[ch_inds, i:j]
                 @test s[ch_inds, t].data == s[ch_inds, i].data
                 @test s[ch_inds, TimeSpan(t, t2)].data == s.data[ch_inds, i:j]
                 @test s[ch_inds, i:j].data == s.data[ch_inds, i:j]
+                reg === :skip && continue # can't represent the index with regex
+                @test s[reg, t].data == s[ch_inds, i].data
+                @test s[reg, TimeSpan(t, t2)].data == s.data[ch_inds, i:j]
+                @test s[reg, i:j].data == s.data[ch_inds, i:j]
             end
             @test size(s[:, TimeSpan(0, Second(1))].data, 2) == floor(s.info.sample_rate)
             for i in 1:length(chs)


### PR DESCRIPTION
This doesn't support nesting, e.g. `samples[[r"o", "f1"], :]`, but we also don't support mixing unit ranges with strings, for example, because one returns a vector of channels and the other a scalar, so I think it's coherent.