### PR TITLE
add DOCUMENTER_KEY to TagBot.yml to attempt to fix docs for tagged releases

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -12,3 +12,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.13.6"
+version = "0.13.7"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"


### PR DESCRIPTION
Looks like Onda's stable docs have been silently (?) failing to update for a while - note the docstring here on the most recent tag:

https://github.com/beacon-biosignals/Onda.jl/blob/v0.13.6/src/annotations.jl#L68-L76

The actual rendered docstring on `stable` still has the materialize kwarg that was deprecated a while ago:

https://beacon-biosignals.github.io/Onda.jl/stable/#Onda.read_annotations

I'm suspecting it's this https://juliadocs.github.io/Documenter.jl/stable/man/hosting/#GitHub-Actions

> In order to deploy documentation for tagged versions, the GitHub Actions workflow needs to be triggered by the tag. However, by default, when the Julia TagBot uses just the GITHUB_TOKEN for authentication, it does not have the permission to trigger any further workflows jobs, and so the documentation CI job never runs for the tag.

But I guess that's new?