### PR TITLE
Use FLAC_jll to avoid implicit system dependency

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,6 @@ jobs:
         arch:
           - x64
     steps:
-      - run: sudo apt-get install -y flac
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0

--- a/Project.toml
+++ b/Project.toml
@@ -22,6 +22,7 @@ Arrow = "1.3"
 CodecZstd = "0.6, 0.7"
 ConstructionBase = "1.0"
 DataFrames = "0.22.7"
+FLAC_jll = "1.3.3"
 JSON3 = "v1.8"
 MsgPack = "1.1"
 Tables = "1.2"
@@ -31,7 +32,8 @@ julia = "1.5"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+FLAC_jll = "1d38b3a6-207b-531b-80e8-c83f48dafa73"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "DataFrames"]
+test = ["FLAC_jll", "DataFrames", "Test"]

--- a/examples/flac.jl
+++ b/examples/flac.jl
@@ -1,8 +1,6 @@
-# This file demonstrates an implementation of FLAC support for Onda.jl. Note
-# that it's a naive implementation - it just shells out and assumes you have
-# the `flac` command line utility installed and available on your system.
+# This file demonstrates an implementation of FLAC support for Onda.jl.
 
-using Onda, Test, Random, Dates
+using Onda, FLAC_jll, Test, Random, Dates
 
 #####
 ##### FLACFormat
@@ -58,13 +56,17 @@ end
 
 function Onda.deserializing_lpcm_stream(format::FLACFormat, io)
     flags = flac_raw_specification_flags(format)
-    cmd = open(`flac - --totally-silent -d --force-raw-format $(flags.endian) $(flags.is_signed)`, io)
+    cmd = flac() do flac_path
+        return open(`$flac_path - --totally-silent -d --force-raw-format $(flags.endian) $(flags.is_signed)`, io)
+    end
     return FLACStream(Onda.LPCMStream(format.lpcm, cmd))
 end
 
 function Onda.serializing_lpcm_stream(format::FLACFormat, io)
     flags = flac_raw_specification_flags(format)
-    cmd = open(`flac --totally-silent $(flags) -`, io; write=true)
+    cmd = flac() do flac_path
+        return open(`$flac_path --totally-silent $(flags) -`, io; write=true)
+    end
     return FLACStream(Onda.LPCMStream(format.lpcm, cmd))
 end
 


### PR DESCRIPTION
Testing locally was failing due to not having `flac` on my system. Better to use FLAC_jll for this to avoid the implicit system dependency.