### PR TITLE
[v0.13] bugfix: correct error for missing metadata

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.13.8"
+version = "0.13.9"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -124,7 +124,7 @@ function table_has_metadata(predicate, table)
     return m isa Dict && predicate(m)
 end
 
-table_has_required_onda_metadata(table) = table_has_metadata(m -> is_supported_onda_format_version(VersionNumber(get(m, "onda_format_version", v"0.0.0"))),
+table_has_required_onda_metadata(table) = table_has_metadata(m -> is_supported_onda_format_version(VersionNumber(get(m, "onda_format_version", "0.0.0"))),
                                                              table)
 
 # It would be better if Arrow.jl supported a generic API for nonstandard path-like types so that

--- a/test/signals.jl
+++ b/test/signals.jl
@@ -121,4 +121,8 @@ end
             @test getfield(s, :_row) == getfield(Signal(r), :_row)
         end
     end
+    signals_file_path = joinpath(root, "test.onda.signals.arrow")
+    Onda.write_arrow_table(signals_file_path, signals) # without metadata
+    @test_throws ArgumentError read_signals(signals_file_path)
+
 end

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -94,4 +94,4 @@ end
     @test_throws ArgumentError setproperties(info; sample_unit="Ha Ha")
     @test_throws ArgumentError setproperties(info; kind="Ha, Ha")
     @test_throws ArgumentError setproperties(info; channel_names=["Ha Ha"])
-  end
+end


### PR DESCRIPTION
Note: this PR is made to a release-v0.13 branch.

When the Onda v0.13 metadata is missing (e.g. you only have Onda v0.14 metadata), we get the default value here, which errors because `VersionNumber` does not accept `VersionNumber`'s (only strings).

This just turns one error into another, but the correct error also tells you what to do if you really need to read the file (which is read the file without validating the metadata). I saw this in an internal project and @kimlaberinto ran into it too, so I think it's worth a backport.