### PR TITLE
Use `write_full_path` from Legolas

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.4"
+version = "0.14.5"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.3"
+version = "0.14.4"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -5,7 +5,7 @@ using UUIDs, Dates, Random, Mmap
 using Compat, TimeSpans, Arrow, Tables, TranscodingStreams, CodecZstd
 using ConstructionBase # here for deprecations only
 using Legolas
-using Legolas: @row
+using Legolas: @row, write_full_path
 
 include("utilities.jl")
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -90,6 +90,3 @@ function read_byte_range(path, byte_offset, byte_count)
 end
 
 read_byte_range(path, ::Missing, ::Missing) = read(path)
-
-write_full_path(path::AbstractString, bytes) = (mkpath(dirname(path)); write(path, bytes))
-write_full_path(path, bytes) = write(path, bytes)


### PR DESCRIPTION
Avoids having duplicate code and allows Onda to use this fix once merged: https://github.com/beacon-biosignals/Legolas.jl/pull/26