### PR TITLE
Raise Julia version to 1.6

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -19,7 +19,7 @@ jobs:
           - '0.3'
           - '0.4'
         version:
-          - '1.4'
+          - '1.6'
           - '1'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -28,7 +28,7 @@ Legolas = "0.2.2, 0.3, 0.4"
 Tables = "1.4"
 TimeSpans = "0.2.2"
 TranscodingStreams = "0.9"
-julia = "1.4"
+julia = "1.6"
 
 [extras]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/examples/Project.toml
+++ b/examples/Project.toml
@@ -1,0 +1,6 @@
+[deps]
+Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Legolas = "741b9549-f6ed-4911-9fbf-4a1c0c97f0cd"
+Onda = "e853f5be-6863-11e9-128d-476edb89bfb5"
+TimeSpans = "bb34ddd2-327f-4c4a-bfb0-c98fc494ece1"


### PR DESCRIPTION
This raises the Julia version from 1.4 to 1.6. It came up in a comment by @ararslan in #124. I might be wrong in *how* I'm attempting this. 