### PR TITLE
allow customizing predicate in `merge_overlapping_annotations`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.6"
+version = "0.14.7"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/annotations.jl
+++ b/src/annotations.jl
@@ -49,14 +49,18 @@ validate_annotations(annotations) = _fully_validate_legolas_table(annotations, L
 #####
 
 """
-    merge_overlapping_annotations(annotations)
+    merge_overlapping_annotations([predicate=TimeSpans.overlaps,] annotations)
 
 Given the `onda.annotation`-compliant table `annotations`, return
-a table corresponding to `annotations` except that overlapping entries have
-been merged.
+a table corresponding to `annotations` except that consecutive entries satisfying `predicate`
+have been merged using `TimeSpans.shortest_timespan_containing`. The predicate
+must be of the form `prediate(next_span::TimeSpan, prev_span::TimeSpan)::Bool`
+returning whether or not to merge the annotations corresponding to
+`next_span` and `prev_span`, where `next_span` is the next span in the same recording as `prev_span`.
 
 Specifically, two annotations `a` and `b` are determined to be "overlapping"
-if `a.recording == b.recording && TimeSpans.overlaps(a.span, b.span)`. Merged
+if `a.recording == b.recording && predicate(a.span, b.span)`, where the default
+value of `predicate` is `TimeSpans.overlaps`. Merged
 annotations' `span` fields are generated via calling `TimeSpans.shortest_timespan_containing`
 on the overlapping set of source annotations.
 
@@ -70,8 +74,10 @@ non-overlapping annotation).
 Note that this function internally works with `Tables.columns(annotations)`
 rather than `annotations` directly, so it may be slower and/or require more
 memory if `!Tables.columnaccess(annotations)`.
+
+See also `TimeSpans.merge_spans` for similar functionality on timespans (instead of annotations).
 """
-function merge_overlapping_annotations(annotations)
+function merge_overlapping_annotations(predicate, annotations)
     columns = Tables.columns(annotations)
     merged = Annotation[]
     for (rid, (locs,)) in Legolas.locations((columns.recording,))
@@ -82,7 +88,7 @@ function merge_overlapping_annotations(annotations)
         push!(merged, Annotation(recording=rid, id=uuid4(), span=init.span, from=[init.id]))
         for next in Iterators.drop(sorted, 1)
             prev = merged[end]
-            if next.recording == prev.recording && TimeSpans.overlaps(next.span, prev.span)
+            if next.recording == prev.recording && predicate(next.span, prev.span)
                 push!(prev.from, next.id)
                 merged[end] = Annotation(Tables.rowmerge(prev; span=TimeSpans.shortest_timespan_containing((prev.span, next.span))))
             else
@@ -92,3 +98,5 @@ function merge_overlapping_annotations(annotations)
     end
     return merged
 end
+
+merge_overlapping_annotations(annotations) = merge_overlapping_annotations(TimeSpans.overlaps, annotations)

--- a/src/annotations.jl
+++ b/src/annotations.jl
@@ -99,4 +99,4 @@ function merge_overlapping_annotations(predicate, annotations)
     return merged
 end
 
-merge_overlapping_annotations(annotations) = merge_overlapping_annotations(TimeSpans.overlaps, annotations)
+merge_overlapping_annotations(annotations) = merge_overlapping_annotations(overlaps, annotations)

--- a/test/annotations.jl
+++ b/test/annotations.jl
@@ -75,7 +75,6 @@ end
     @test Tables.columnnames(merged) == (:recording, :id, :span, :from)
     sources_id = [row.id for row in sources]
     @test !any(in(id, sources_id) for id in merged.id)
-    global merged, expected, sources
     merged = @compat Set(Tables.rowtable((; merged.recording, merged.span, merged.from)))
     expected = Set([(recording=recs[1], span=TimeSpan(0, 176), from=[sources[1].id, sources[3].id, sources[7].id, sources[10].id, sources[4].id]),
                     (recording=recs[1], span=TimeSpan(200, 300), from=[sources[14].id]),

--- a/test/annotations.jl
+++ b/test/annotations.jl
@@ -67,4 +67,19 @@ end
                     (recording=recs[3], span=TimeSpan(100, 110), from=[sources[13].id]),
                     (recording=recs[3], span=TimeSpan(0, 100), from=[sources[8].id, sources[12].id, sources[11].id])])
     @test expected == merged
+
+    # now let's try where we merge consecutive spans even if there's a gap, if it's less than 15 ns
+    predicate(next, prev) = start(next) - stop(prev) < Nanosecond(15)
+    
+    merged = Tables.columns(merge_overlapping_annotations(predicate, sources))
+    @test Tables.columnnames(merged) == (:recording, :id, :span, :from)
+    sources_id = [row.id for row in sources]
+    @test !any(in(id, sources_id) for id in merged.id)
+    global merged, expected, sources
+    merged = @compat Set(Tables.rowtable((; merged.recording, merged.span, merged.from)))
+    expected = Set([(recording=recs[1], span=TimeSpan(0, 176), from=[sources[1].id, sources[3].id, sources[7].id, sources[10].id, sources[4].id]),
+                    (recording=recs[1], span=TimeSpan(200, 300), from=[sources[14].id]),
+                    (recording=recs[2], span=TimeSpan(2, 170), from=[sources[9].id, sources[6].id, sources[2].id, sources[5].id]),
+                    (recording=recs[3], span=TimeSpan(0, 110), from=[sources[8].id, sources[12].id, sources[11].id, sources[13].id])])
+    @test expected == merged
 end


### PR DESCRIPTION
This is pretty useful! TimeSpans has `merge_spans` which does this (with the same semantics), but it is helpful to have the feature at the level of annotations.