### PR TITLE
add `Base.copy` implementation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.14.8"
+version = "0.14.9"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -66,8 +66,9 @@ Base.:(==)(a::Samples, b::Samples) = a.encoded == b.encoded && a.info == b.info 
 """
     copy(a::Samples)
 
-Copies a `Samples` object by `copy`ing its fields. The resulting samples object's data and e.g. `samples.info.channels`
-will not alias with the original. See also [`Base.copy(::SamplesInfo)`](@ref).
+Copy a `Samples` object by `copy`ing its fields. The resulting `Samples` object's data
+and any container-valued `SamplesInfo` fields, e.g. the vector of channel names, will
+not alias the originals. See also [`Base.copy(::SamplesInfo)`](@ref).
 """
 Base.copy(a::Samples) = Samples(copy(a.data), copy(a.info), a.encoded)
 

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -64,6 +64,14 @@ Returns `a.encoded == b.encoded && a.info == b.info && a.data == b.data`.
 Base.:(==)(a::Samples, b::Samples) = a.encoded == b.encoded && a.info == b.info && a.data == b.data
 
 """
+    copy(a::Samples)
+
+Copies a `Samples` object by `copy`ing its fields. The resulting samples object's data and e.g. `samples.info.channels`
+will not alias with the original. See also [`Base.copy(::SamplesInfo)`](@ref).
+"""
+Base.copy(a::Samples) = Samples(copy(a.data), copy(a.info), a.encoded)
+
+"""
     validate(samples::Samples)
 
 Returns `nothing`, checking that the given `samples` are valid w.r.t. the

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -76,17 +76,7 @@ Create a new `SamplesInfo` by performing a shallow `copy` of each of its fields,
 In particular, the result's `channels` will not alias with the original.
 """
 function Base.copy(s::SamplesInfo)
-    maybe_copy = (k, v) -> begin
-        if k === :channels
-            return copy(v)
-        elseif k in (:kind, :sample_unit, :sample_resolution_in_unit, :sample_offset_in_unit, :sample_type, :sample_rate)
-            return v
-        else
-            # We don't know ahead of time if we *can* `copy` the field, so we check first.
-            return Base.applicable(copy, v) ? copy(v) : v
-        end
-    end
-    return SamplesInfo(; (k => maybe_copy(k, getproperty(s, k)) for k in propertynames(s))...)
+    return SamplesInfo(map(v -> Base.applicable(copy, v) ? copy(v) : v, getfield(s, :fields)))
 end
 
 #####

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -68,6 +68,27 @@ const SamplesInfo = @row("onda.samples-info@1",
                          sample_type::AbstractString = onda_sample_type_from_julia_type(sample_type),
                          sample_rate::LPCM_SAMPLE_TYPE_UNION = convert_number_to_lpcm_sample_type(sample_rate))
 
+
+"""
+    Base.copy(s::SamplesInfo)
+
+Create a new `SamplesInfo` by performing a shallow `copy` of each of its fields, if possible according to `Base.applicable`.
+In particular, the result's `channels` will not alias with the original.
+"""
+function Base.copy(s::SamplesInfo)
+    maybe_copy = (k, v) -> begin
+        if k === :channels
+            return copy(v)
+        elseif k in (:kind, :sample_unit, :sample_resolution_in_unit, :sample_offset_in_unit, :sample_type, :sample_rate)
+            return v
+        else
+            # We don't know ahead of time if we *can* `copy` the field, so we check first.
+            return Base.applicable(copy, v) ? copy(v) : v
+        end
+    end
+    return SamplesInfo(; (k => maybe_copy(k, getproperty(s, k)) for k in propertynames(s))...)
+end
+
 #####
 ##### `Signal`
 #####

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -72,11 +72,12 @@ const SamplesInfo = @row("onda.samples-info@1",
 """
     Base.copy(s::SamplesInfo)
 
-Create a new `SamplesInfo` by performing a shallow `copy` of each of its fields, if possible according to `Base.applicable`.
+Call `copy` on each field of the given `SamplesInfo` for which an applicable `copy` method
+exists and return the resulting `SamplesInfo`.
 In particular, the result's `channels` will not alias with the original.
 """
 function Base.copy(s::SamplesInfo)
-    return SamplesInfo(map(v -> Base.applicable(copy, v) ? copy(v) : v, getfield(s, :fields)))
+    return SamplesInfo(map(v -> applicable(copy, v) ? copy(v) : v, getfield(s, :fields)))
 end
 
 #####

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -203,11 +203,11 @@ end
                        sample_type=Int16,
                        sample_rate=100.0,
                        # Copyable
-                       array = ["hi"],
+                       array=["hi"],
                        # Not copyable
-                       string = "hi",
+                       string="hi",
                        # This is to test we are doing a shallow copy
-                       array_deep = [["hi"]])
+                       array_deep=[["hi"]])
 
     copy_info = copy(info)
     @test copy_info == info


### PR DESCRIPTION
I have seen a proliferation of `deepcopy` on Samples objects in Beacon-internal projects, and generally when I see `deepcopy` I think there's a missing `copy` method.  

The internal use cases I have seen generally have the requirement that the data is copied, as well as the `channels` vector in the info object. E.g. you may want to `copy`, then perform an in-place montaging that updates the `channels` vector, and want the original unaffected.

That motivated the implementation here, where we shallow-copy each field of the `SamplesInfo`.

If we don't like this approach we could decide `deepcopy` is indeed the right approach for this. I benchmarked after implementing, and here `deepcopy` isn't that bad for performance (probably because it's mostly a big chunk of contiguous data, which Julia's serializer is optimized for):
```julia
julia> info = SamplesInfo(kind="eeg",channels=string.(1:19), sample_unit="unit",
                              sample_resolution_in_unit=1.0,
                              sample_offset_in_unit=0.0,
                              sample_type=Int16,
                              sample_rate=100.0)
Row(Schema("onda.samples-info@1"), (kind = "eeg", channels = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19"], sample_unit = "unit", sample_resolution_in_unit = 1.0, sample_offset_in_unit = 0.0, sample_type = "int16", sample_rate = 100.0))

julia> samples = Samples(rand(sample_type(info), 19, 153600), info, true); # ~20 minutes of EEG

julia> @btime copy($samples);
  188.167 μs (30 allocations: 5.57 MiB)

julia> @btime deepcopy($samples);
  192.917 μs (40 allocations: 5.57 MiB)

julia> samples = decode(samples);

julia> @btime copy($samples);
  273.834 μs (30 allocations: 5.57 MiB)

julia> @btime deepcopy($samples);
  279.000 μs (40 allocations: 5.57 MiB)
```