### PR TITLE
Bump documenter version

### DIFF
--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Onda = "e853f5be-6863-11e9-128d-476edb89bfb5"
 
 [compat]
-Documenter = "0.24"
+Documenter = "0.27"


### PR DESCRIPTION
For some reason, the ["dev"](https://beacon-biosignals.github.io/Onda.jl/dev/) docs are out of date. Maybe a newer documenter version will fix this?