### PR TITLE
Improve schema version docstrings

### DIFF
--- a/src/annotations.jl
+++ b/src/annotations.jl
@@ -4,6 +4,22 @@
 
 @schema "onda.annotation" Annotation
 
+"""
+    AnnotationV1
+
+A [Legolas](https://github.com/beacon-biosignals/Legolas.jl)-generated record type
+implementing the [`onda.annotation@1`](https://github.com/beacon-biosignals/Onda.jl##ondaannotation1)
+specification as described by the [Onda Format Specification](https://github.com/beacon-biosignals/Onda.jl#the-onda-format-specification).
+
+# Required Fields
+
+- `recording::UUID`: The UUID identifying the recording with which the annotation is
+  associated.
+- `id::UUID`: The UUID identifying the annotation.
+- `span::TimeSpan`: The annotation's time span within the recording.
+"""
+AnnotationV1
+
 @version AnnotationV1 begin
     recording::UUID = UUID(recording)
     id::UUID = UUID(id)
@@ -11,19 +27,6 @@
 end
 
 Legolas.accepted_field_type(::AnnotationV1SchemaVersion, ::Type{TimeSpan}) = Union{NamedTupleTimeSpan,TimeSpan}
-
-"""
-    @version AnnotationV1 begin
-        recording::UUID
-        id::UUID
-        span::TimeSpan
-    end
-
-A Legolas-generated record type representing an [`onda.annotation` as described by the Onda Format Specification](https://github.com/beacon-biosignals/Onda.jl##ondaannotation1).
-
-See https://github.com/beacon-biosignals/Legolas.jl for details regarding Legolas record types.
-"""
-AnnotationV1
 
 """
     validate_annotations(annotations)
@@ -45,23 +48,23 @@ validate_annotations(annotations) = _fully_validate_legolas_table(:validate_anno
 
 @schema "onda.merged-annotation" MergedAnnotation
 
+"""
+    MergedAnnotationV1 > AnnotationV1
+
+A [Legolas](https://github.com/beacon-biosignals/Legolas.jl)-generated record type
+representing an annotation derived from "merging" one or more existing annotations.
+
+# Required Fields
+
+All fields required by [`AnnotationV1`](@ref), and:
+
+- `from::Vector{UUID}`: The `id`s of the annotation's source annotation(s).
+"""
+MergedAnnotationV1
+
 @version MergedAnnotationV1 > AnnotationV1 begin
     from::Vector{UUID}
 end
-
-"""
-    @version MergedAnnotationV1 > AnnotationV1 begin
-        from::Vector{UUID}
-    end
-
-A Legolas-generated record type representing an annotation derived from "merging" one or more existing annotations.
-
-This record type extends `AnnotationV1` with a single additional required field, `from::Vector{UUID}`, whose entries
-are the `id`s of the annotation's source annotation(s).
-
-See https://github.com/beacon-biosignals/Legolas.jl for details regarding Legolas record types.
-"""
-MergedAnnotationV1
 
 """
     merge_overlapping_annotations([predicate=TimeSpans.overlaps,] annotations)

--- a/src/signals.jl
+++ b/src/signals.jl
@@ -73,6 +73,29 @@ end
 
 @schema "onda.samples-info" SamplesInfo
 
+"""
+    SamplesInfoV2
+
+A [Legolas](https://github.com/beacon-biosignals/Legolas.jl)-generated record type
+representing the bundle of [`onda.signal@2`](https://github.com/beacon-biosignals/Onda.jl#ondasignal2)
+fields that are intrinsic to a signal's sample data, leaving out extrinsic file or recording
+information. This is useful when the latter information is irrelevant or does not yet exist
+(e.g. if sample data is being constructed/manipulated in-memory without yet having been
+serialized).
+
+# Required Fields
+
+- `sensor_type::String`
+- `sensor_type::String`
+- `channels::Vector{String}`
+- `sample_unit::String`
+- `sample_resolution_in_unit::Float64`
+- `sample_offset_in_unit::Float64`
+- `sample_type::String`
+- `sample_rate::Float64`
+"""
+SamplesInfoV2
+
 @version SamplesInfoV2 begin
     sensor_type::String
     channels::Vector{String}
@@ -86,26 +109,6 @@ end
 Legolas.accepted_field_type(::SamplesInfoV2SchemaVersion, ::Type{String}) = AbstractString
 Legolas.accepted_field_type(::SamplesInfoV2SchemaVersion, ::Type{Vector{String}}) = AbstractVector{<:AbstractString}
 
-"""
-    @version SamplesInfoV2 begin
-        sensor_type::String
-        channels::Vector{String}
-        sample_unit::String
-        sample_resolution_in_unit::Float64
-        sample_offset_in_unit::Float64
-        sample_type::String = onda_sample_type_from_julia_type(sample_type)
-        sample_rate::Float64
-    end
-
-A Legolas-generated record type representing the bundle of `onda.signal` fields that are intrinsic to a
-signal's sample data, leaving out extrinsic file or recording information. This is useful when the latter
-information is irrelevant or does not yet exist (e.g. if sample data is being constructed/manipulated in-memory
-without yet having been serialized).
-
-See https://github.com/beacon-biosignals/Legolas.jl for details regarding Legolas record types.
-"""
-SamplesInfoV2
-
 # xref https://github.com/beacon-biosignals/Legolas.jl/issues/61
 Base.copy(info::SamplesInfoV2) = SamplesInfoV2(; info.sensor_type, channels=copy(info.channels),
                                                info.sample_unit, info.sample_resolution_in_unit,
@@ -117,6 +120,28 @@ Base.copy(info::SamplesInfoV2) = SamplesInfoV2(; info.sensor_type, channels=copy
 #####
 
 @schema "onda.signal" Signal
+
+"""
+    SignalV2 > SamplesInfoV2
+
+A [Legolas](https://github.com/beacon-biosignals/Legolas.jl)-generated record type
+implementing the [`onda.signal@2`](https://github.com/beacon-biosignals/Onda.jl##ondasignal2)
+specification as described by the [Onda Format Specification](https://github.com/beacon-biosignals/Onda.jl#the-onda-format-specification).
+
+# Required Fields
+
+All fields required by [`SamplesInfoV2`](@ref), and:
+
+- `recording::UUID`
+- `file_path::(<:Any)`
+- `file_format::String`
+- `span::TimeSpan`
+- `sensor_label::String`
+- `sensor_type::String`
+- `channels::Vector{String}`
+- `sample_unit::String`
+"""
+SignalV2
 
 @version SignalV2 > SamplesInfoV2 begin
     recording::UUID = UUID(recording)
@@ -132,27 +157,6 @@ end
 Legolas.accepted_field_type(::SignalV2SchemaVersion, ::Type{TimeSpan}) = Union{NamedTupleTimeSpan,TimeSpan}
 Legolas.accepted_field_type(::SignalV2SchemaVersion, ::Type{String}) = AbstractString
 Legolas.accepted_field_type(::SignalV2SchemaVersion, ::Type{Vector{String}}) = AbstractVector{<:AbstractString}
-
-"""
-    @version SignalV2 > SamplesInfoV2 begin
-        recording::UUID
-        file_path::(<:Any)
-        file_format::String
-        span::TimeSpan
-        sensor_label::String
-        sensor_type::String
-        channels::Vector{String}
-        sample_unit::String
-    end
-
-A Legolas-generated record type representing an [`onda.signal` as described by the Onda Format Specification](https://github.com/beacon-biosignals/Onda.jl##ondasignal2).
-
-Note that some fields documented as required fields of `onda.signal@2` in the Onda Format Specification
-are captured via this schema version's extension of `SamplesInfoV2`.
-
-See https://github.com/beacon-biosignals/Legolas.jl for details regarding Legolas record types.
-"""
-SignalV2
 
 """
     validate_signals(signals)


### PR DESCRIPTION
While updating some other Julia packages to use Legolas 0.5 I noticed a pattern where documentation for Legolas schema versions ended up just copying the schema version definition into the docstring. That style of docstring isn't very human friendly so I decided to try out some of the concepts we've been playing with in a private package here for consideration.

Changes made:
- Placed docstrings before `@version` definitions. This still attaches the docstring to the struct and matches the typical Julia docstring being placed above the definition (Legolas 0.5 doesn't allow you to attach the docstring directly to the `@version` macro ATM)
- Improve the description of the Onda defined schema versions to mention the Julia type itself is just implementing of a specification
- Break out the required fields as separate bullet points which make it much easier to read. This provides us a way to add descriptions to each field
- When schema versions inherit fields I'm referencing the documentation of that schema version to make it easy to determine the complete set of fields needed to be defined by the Legolas schema.
