### PR TITLE
throw an informative error when a channel is not found

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.0"
+version = "0.15.1"
 
 
 [deps]

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -157,7 +157,11 @@ _indices_fallback(f, samples::Samples, x) = map(x -> f(samples, x), x)
 row_arguments(samples::Samples, x) = _rangify(_row_arguments(samples, x))
 
 _row_arguments(samples::Samples, x) = _indices_fallback(_row_arguments, samples, x)
-_row_arguments(samples::Samples, name::AbstractString) = channel(samples, name)
+function _row_arguments(samples::Samples, name::AbstractString)
+    idx = channel(samples, name)
+    idx === nothing && throw(ArgumentError("channel \"$(name)\" not found"))
+    return idx
+end
 _row_arguments(samples::Samples, name::Regex) = findall(c -> match(name, c) !== nothing, samples.info.channels)
 
 column_arguments(samples::Samples, x) = _rangify(_column_arguments(samples, x))

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -120,6 +120,20 @@
     end
 end
 
+@testset "`Samples` indexing errors" begin
+    info = SamplesInfoV2(sensor_type="eeg",
+                         channels=["a", "b", "c-d"],
+                         sample_unit="unit",
+                         sample_resolution_in_unit=0.25,
+                         sample_offset_in_unit=-0.5,
+                         sample_type=Int16,
+                         sample_rate=50.2)
+
+    samples = Samples(rand(Random.MersenneTwister(0), sample_type(info), 3, 5), info, true)
+
+    @test_throws ArgumentError("channel \"aa\" not found") samples["aa", :]
+end
+
 @testset "`Samples` pretty printing" begin
     info = SamplesInfoV2(sensor_type="eeg",
                          channels=["a", "b", "c-d"],


### PR DESCRIPTION
Currently, the error that's thrown when a channel is not found is pretty hard to
interpret (complains about indexing with a `nothing`).  This PR adds a check
which intercepts the `nothing` returned by `channel(...)` when a channel is not
found, and throws a better error which mentions the channel not found by name.
This doesn't cover _all_ the scenarios (e.g., if there are >1 channels not
found, it'll only raise the first one) but it's an improvement that's not
breaking (and so can be backported to a 0.14 release).