### PR TITLE
add ContextlessAnnotation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.1"
+version = "0.15.2"
 
 
 [deps]

--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -10,7 +10,8 @@ include("utilities.jl")
 
 include("annotations.jl")
 export AnnotationV1, AnnotationV1SchemaVersion, MergedAnnotationV1, MergedAnnotationV1SchemaVersion,
-       validate_annotations, merge_overlapping_annotations
+       validate_annotations, merge_overlapping_annotations,
+       ContextlessAnnotationV1, add_context
 
 include("signals.jl")
 export SamplesInfoV2, SamplesInfoV2SchemaVersion, SignalV2, SignalV2SchemaVersion,

--- a/src/annotations.jl
+++ b/src/annotations.jl
@@ -104,3 +104,40 @@ function merge_overlapping_annotations(predicate, annotations)
 end
 
 merge_overlapping_annotations(annotations) = merge_overlapping_annotations(overlaps, annotations)
+
+@schema "onda.contextless-annotation" ContextlessAnnotation
+
+"""
+    @version ContextlessAnnotationV1 begin
+        id::UUID
+        span::TimeSpan
+    end
+
+Represents an event that occurs at some span `span` in a situation in which the broader context of the recording
+and what the `span` is relative to is not available.
+
+This can be useful when annotations are being generated from [`Samples`](@ref) objects, without the context of the [`SignalV2`](@ref)
+that these samples came from.
+
+These can be upgraded to full `AnnotationV1`'s via [`add_context`](@ref).
+"""
+ContextlessAnnotationV1
+
+@version ContextlessAnnotationV1 begin
+    id::UUID
+    span::TimeSpan
+end
+
+"""
+    add_context(contextless; recording, start) -> AnnotationV1
+
+Given a contextless annotation (see also [`ContextlessAnnotationV1`](@ref)), adds the context of the `recording`
+associated to this annotation, and the `start` time relative to the recording.
+
+For example, if you load a signal `signal` (and hence know the recording and start of the signal relative to the recording),
+to obtain a `Samples` object, and then generate contextless annotations from that samples object alone (e.g. via another library),
+you can "upgrade" these to full annotations by `add_context(contextless; signal.recording, start=start(signal.span))`.
+
+This function simply translates the `span` field of `contextless` by `start` and adds the recording field.
+"""
+add_context(contextless; recording, start) = AnnotationV1(; contextless.id, recording, span=translate(contextless.span, start))

--- a/test/annotations.jl
+++ b/test/annotations.jl
@@ -19,20 +19,20 @@ end
 
 @testset "`merge_overlapping_annotations`" begin
     recs = (uuid4(), uuid4(), uuid4())
-    sources = [#= 1 =#  AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(0, 100)),
-               #= 2 =#  AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(55, 100)),
-               #= 3 =#  AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(34, 76)),
-               #= 4 =#  AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(120, 176)),
-               #= 5 =#  AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(67, 95)),
-               #= 6 =#  AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(15, 170)),
-               #= 7 =#  AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(43, 89)),
-               #= 8 =#  AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(0, 50)),
-               #= 9 =#  AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(2, 10)),
-               #= 10 =# AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(111, 140)),
-               #= 11 =# AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(60, 100)),
-               #= 12 =# AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(23, 80)),
-               #= 13 =# AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(100, 110)),
-               #= 14 =# AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(200, 300))]
+    sources = [AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(0, 100)), #= 1 =#
+        AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(55, 100)),               #= 2 =#
+        AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(34, 76)),               #= 3 =#
+        AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(120, 176)),               #= 4 =#
+        AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(67, 95)),               #= 5 =#
+        AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(15, 170)),               #= 6 =#
+        AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(43, 89)),               #= 7 =#
+        AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(0, 50)),               #= 8 =#
+        AnnotationV1(recording=recs[2], id=uuid4(), span=TimeSpan(2, 10)),               #= 9 =#
+        AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(111, 140)),               #= 10 =#
+        AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(60, 100)),               #= 11 =#
+        AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(23, 80)),               #= 12 =#
+        AnnotationV1(recording=recs[3], id=uuid4(), span=TimeSpan(100, 110)),               #= 13 =#
+        AnnotationV1(recording=recs[1], id=uuid4(), span=TimeSpan(200, 300))]               #= 14 =#
     merged = merge_overlapping_annotations(sources)
     @test merged isa Vector{MergedAnnotationV1}
     merged = Tables.columns(merged)
@@ -41,12 +41,12 @@ end
     @test !any(in(id, sources_id) for id in merged.id)
     merged = @compat Set(Tables.rowtable((; merged.recording, merged.span, merged.from)))
     expected = Set([(recording=recs[1], span=TimeSpan(0, 100), from=[sources[1].id, sources[3].id, sources[7].id]),
-                    (recording=recs[1], span=TimeSpan(111, 176), from=[sources[10].id, sources[4].id]),
-                    (recording=recs[1], span=TimeSpan(200, 300), from=[sources[14].id]),
-                    (recording=recs[2], span=TimeSpan(15, 170), from=[sources[6].id, sources[2].id, sources[5].id]),
-                    (recording=recs[2], span=TimeSpan(2, 10), from=[sources[9].id]),
-                    (recording=recs[3], span=TimeSpan(100, 110), from=[sources[13].id]),
-                    (recording=recs[3], span=TimeSpan(0, 100), from=[sources[8].id, sources[12].id, sources[11].id])])
+        (recording=recs[1], span=TimeSpan(111, 176), from=[sources[10].id, sources[4].id]),
+        (recording=recs[1], span=TimeSpan(200, 300), from=[sources[14].id]),
+        (recording=recs[2], span=TimeSpan(15, 170), from=[sources[6].id, sources[2].id, sources[5].id]),
+        (recording=recs[2], span=TimeSpan(2, 10), from=[sources[9].id]),
+        (recording=recs[3], span=TimeSpan(100, 110), from=[sources[13].id]),
+        (recording=recs[3], span=TimeSpan(0, 100), from=[sources[8].id, sources[12].id, sources[11].id])])
     @test expected == merged
 
     # now let's try where we merge consecutive spans even if there's a gap, if it's less than 15 ns
@@ -58,8 +58,32 @@ end
     @test !any(in(id, sources_id) for id in merged.id)
     merged = @compat Set(Tables.rowtable((; merged.recording, merged.span, merged.from)))
     expected = Set([(recording=recs[1], span=TimeSpan(0, 176), from=[sources[1].id, sources[3].id, sources[7].id, sources[10].id, sources[4].id]),
-                    (recording=recs[1], span=TimeSpan(200, 300), from=[sources[14].id]),
-                    (recording=recs[2], span=TimeSpan(2, 170), from=[sources[9].id, sources[6].id, sources[2].id, sources[5].id]),
-                    (recording=recs[3], span=TimeSpan(0, 110), from=[sources[8].id, sources[12].id, sources[11].id, sources[13].id])])
+        (recording=recs[1], span=TimeSpan(200, 300), from=[sources[14].id]),
+        (recording=recs[2], span=TimeSpan(2, 170), from=[sources[9].id, sources[6].id, sources[2].id, sources[5].id]),
+        (recording=recs[3], span=TimeSpan(0, 110), from=[sources[8].id, sources[12].id, sources[11].id, sources[13].id])])
     @test expected == merged
+end
+
+@testset "contextless-annotation" begin
+    c = ContextlessAnnotationV1(; id=uuid4(), span=TimeSpan(2, 3))
+
+    recording = uuid4()
+    ann = add_context(c; recording, start=Nanosecond(5))
+    @test ann isa AnnotationV1
+    @test ann.id == c.id
+    @test ann.recording == recording
+
+    # What is the right answer? Let us draw a diagram
+    # (---------------recording----------------------------------------)
+    #         (--------signal---------------------------)
+    #                (----contextless.span-----)
+    # -------> start(signal.span)
+    #         ------> start(contextless.span)
+    # --------------> start(translate(contextless.span, start(signal.span)))
+
+    @test ann.span == TimeSpan(7, 8)
+
+    # Can use other types. Extra columns are ignored.
+    ann2 = add_context(Tables.rowmerge(c; garbo="hi"); recording, start=Nanosecond(5))
+    @test ann2 == ann
 end


### PR DESCRIPTION
when one only has a Samples object (and not a signal), and they run some algorithm over it that generates annotations, that algo doesn’t have the context of recording or start of the signal, and can only output things relative to the samples itself. That leads to the need for something like this `ContextlessSpanV1`.

More beacon-internal context: https://beacon-biosignals.slack.com/archives/CKS1Y5F5X/p1695907224398859