### PR TITLE
use fma in decoding

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.4"
+version = "0.15.5"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -359,7 +359,7 @@ end
 """
     decode(sample_resolution_in_unit, sample_offset_in_unit, sample_data)
 
-Return `sample_resolution_in_unit .* sample_data .+ sample_offset_in_unit`.
+Return `fma.(sample_resolution_in_unit, sample_data, sample_offset_in_unit)`.
 
 If:
 
@@ -373,7 +373,7 @@ function decode(sample_resolution_in_unit, sample_offset_in_unit, sample_data)
     if sample_data isa AbstractArray
         isone(sample_resolution_in_unit) && iszero(sample_offset_in_unit) && return sample_data
     end
-    return sample_resolution_in_unit .* sample_data .+ sample_offset_in_unit
+    return fma.(sample_resolution_in_unit, sample_data, sample_offset_in_unit)
 end
 
 """
@@ -383,7 +383,7 @@ Similar to `decode(sample_resolution_in_unit, sample_offset_in_unit, sample_data
 write decoded values to `result_storage` rather than allocating new storage.
 """
 function decode!(result_storage, sample_resolution_in_unit, sample_offset_in_unit, sample_data)
-    f = x -> sample_resolution_in_unit * x + sample_offset_in_unit
+    f = x -> fma(sample_resolution_in_unit, x, sample_offset_in_unit)
     return broadcast!(f, result_storage, sample_data)
 end
 


### PR DESCRIPTION
closes https://github.com/beacon-biosignals/Onda.jl/issues/146

Here the main question is whether to use `muladd` or `fma`. Quoting the `muladd` doctsring,

> help?> Base.muladd
>   muladd(x, y, z)
> 
>   Combined multiply-add: computes x*y+z, but allowing the add and multiply to be merged with each other or with surrounding operations for
>   performance. For example, this may be implemented as an fma if the hardware supports it efficiently. The result can be different on different
>   machines and can also be different on the same machine due to constant propagation or other optimizations. See fma.

The result being different on different machines sounds like the kind of thing we don't want to have to worry about with encode/decode when trying to track down reproducibility issues etc. Moreover, `fma` is widely available now. So I think it makes sense to stick with `fma` for an accuracy boost and speedup on most hardware, at the potential cost of a big slowdown for software emulation on unsupported hardware. I think all the hardware used at Beacon supports fma.

Note the existing tests pass as-is, including some floating point `==` tests, which I guess means we were already rounding correctly on the test data (?).