### PR TITLE
fix bug in hashing samples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.3"
+version = "0.15.4"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -74,6 +74,12 @@ function Base.isequal(a::Samples, b::Samples)
     return isequal(a.encoded, b.encoded) && isequal(a.info, b.info) && isequal(a.data, b.data)
 end
 
+# Define in a compatible way as `isequal` so that two samples being `isequal` to each other
+# ensures they have the same hash.
+function Base.hash(a::Samples, h::UInt)
+    return hash(Samples, hash(a.encoded, hash(a.info, hash(a.data, h))))
+end
+
 """
     copy(s::Samples)
 

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -228,7 +228,7 @@ end
     @test copy_samples.info.channels !== info.channels === samples.info.channels
 end
 
-@testset "Base.isequal" begin
+@testset "Base.isequal and Base.hash" begin
     info = SamplesInfoV2(sensor_type="eeg",
                          channels=["a", "b", "c"],
                          sample_unit="unit",
@@ -244,6 +244,7 @@ end
     samples.data[1,1] = samples2.data[1,1] = NaN
     @test samples != samples2
     @test isequal(samples, samples2)
+    @test hash(samples) == hash(samples2)
 end
 
 @testset "Samples views" begin


### PR DESCRIPTION
The test I added fails on main:
```julia
julia> @test hash(samples) == hash(samples2)
Test Failed at REPL[23]:1
  Expression: hash(samples) == hash(samples2)
   Evaluated: 0x9bab1974999310ac == 0x877a3e1403901e84
```
but passes on this PR.

closes https://github.com/beacon-biosignals/Onda.jl/issues/150