### PR TITLE
Remove pirated ArrowTypes/TimeSpans interop

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.5"
+version = "0.15.6"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"
@@ -32,7 +32,7 @@ FLAC_jll = "1.3.3"
 Legolas = "0.5"
 Minio = "0.2"
 Tables = "1.4"
-TimeSpans = "0.3.4, 1"
+TimeSpans = "1.1"
 TranscodingStreams = "0.9"
 julia = "1.6"
 

--- a/src/utilities.jl
+++ b/src/utilities.jl
@@ -65,9 +65,6 @@ TimeSpans.stop(x::NamedTupleTimeSpan) = x.stop
 
 const TIME_SPAN_ARROW_NAME = Symbol("JuliaLang.TimeSpan")
 
-Arrow.ArrowTypes.arrowname(::Type{TimeSpan}) = TIME_SPAN_ARROW_NAME
-ArrowTypes.JuliaType(::Val{TIME_SPAN_ARROW_NAME}) = TimeSpan
-
 #####
 ##### zstd_compress/zstd_decompress
 #####


### PR DESCRIPTION
Onda currently defines Arrow (de)serialization for `TimeSpan`. This functionality is being moved to an ArrowTypes extension for TimeSpans, which will be released in TimeSpans 1.1.0. Having the same methods defined in Onda and the extension causes precompilation to fail. To fix this, we can simply delete the pirated interoperability between ArrowTypes and TimeSpans and set the TimeSpans compatibility to 1.1.0.

This requires https://github.com/JuliaRegistries/General/pull/99991 (✅) and https://github.com/beacon-biosignals/TimeSpans.jl/pull/61.