### PR TITLE
Fix return type of `encode_sample`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.7"
+version = "0.15.8"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -195,7 +195,7 @@ function encode_sample(::Type{S}, resolution_in_unit, offset_in_unit, sample_in_
     sample_in_unit += noise
     isnan(sample_in_unit) && S <: Integer && return typemax(S)
     from_unit = clamp((sample_in_unit - offset_in_unit) / resolution_in_unit, typemin(S), typemax(S))
-    return S <: Integer ? round(S, from_unit) : from_unit
+    return S <: Integer ? round(S, from_unit) : convert(S, from_unit)
 end
 
 function dither_noise!(rng::AbstractRNG, storage, step)

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -120,6 +120,22 @@
     end
 end
 
+@testset "`encode_sample`" begin
+    @testset "return specified type" begin
+        @test Onda.encode_sample(Float32, 1, 0, 5) === Float32(5)
+    end
+
+    @testset "clamping" begin
+        @test Onda.encode_sample(Int8, 1, 0, -200) == Int8(-128)
+        @test Onda.encode_sample(Int8, 1, 0, 200) == Int8(127)
+    end
+
+    @testset "rounding" begin
+        @test Onda.encode_sample(Float64, 3, 0, 200) === Float64(200 / 3)
+        @test Onda.encode_sample(Int8, 3, 0, 200) === Int8(67)
+    end
+end
+
 @testset "`Samples` indexing errors" begin
     info = SamplesInfoV2(sensor_type="eeg",
                          channels=["a", "b", "c-d"],


### PR DESCRIPTION
Broke off this non-breaking change from #163 