### PR TITLE
Bump TranscodingStreams compat

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -33,7 +33,7 @@ Legolas = "0.5"
 Minio = "0.2"
 Tables = "1.4"
 TimeSpans = "1.1"
-TranscodingStreams = "0.9"
+TranscodingStreams = "0.9, 0.10, 0.11"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
This PR also removes the use of the internal `TranscodingStreams.changemode!` function. This function may be broken in a future release of `TranscodingStreams`. Ref: https://github.com/JuliaVTK/WriteVTK.jl/pull/137

TranscodingStreams v0.11 release notes: https://github.com/JuliaIO/TranscodingStreams.jl/releases/tag/v0.11.0

This release shouldn't effect this package because from what I can tell there is no use of `eof`, `seekend`, or `TranscodingStreams.Memory`