### PR TITLE
define `convert` for Samples

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.7"
+version = "0.15.8"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -81,8 +81,7 @@ function Base.hash(a::Samples, h::UInt)
 end
 
 function Base.convert(::Type{Samples{T}}, samples::Samples) where {T}
-    (; data, info, encoded) = samples
-    return Samples(convert(T, data), info, encoded)
+    return Samples(convert(T, samples.data), samples.info, samples.encoded)
 end
 
 """

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -81,6 +81,7 @@ function Base.hash(a::Samples, h::UInt)
 end
 
 function Base.convert(::Type{Samples{T}}, samples::Samples) where {T}
+    samples.encoded && throw(ArgumentError("can't `convert` encoded samples; use `decode` first"))
     return Samples(convert(T, samples.data), samples.info, samples.encoded)
 end
 

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -80,6 +80,11 @@ function Base.hash(a::Samples, h::UInt)
     return hash(Samples, hash(a.encoded, hash(a.info, hash(a.data, h))))
 end
 
+function Base.convert(::Type{Samples{T}}, samples::Samples) where {T}
+    (; data, info, encoded) = samples
+    return Samples(convert(T, data), info, encoded)
+end
+
 """
     copy(s::Samples)
 

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -244,7 +244,7 @@ end
     # implicitly, and changing the encoding parameters seems like too big of a change.
     # Therefore, validation errors.
     samples = Samples(rand(sample_type(info), 3, 100), info, true)
-    err = ArgumentError("encoded `data` matrix eltype does not match `sample_type(info)`")
+    err = ArgumentError("can't `convert` encoded samples; use `decode` first")
     @test_throws err convert(Samples{Matrix{Int32}}, samples)
 end
 

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -242,7 +242,6 @@ end
     # For encoded samples, in generally we cannot `convert`.
     # We choose to not update encoding parameter in `convert`, since `convert` can be implied
     # implicitly, and changing the encoding parameters seems like too big of a change.
-    # Therefore, validation errors.
     samples = Samples(rand(sample_type(info), 3, 100), info, true)
     err = ArgumentError("can't `convert` encoded samples; use `decode` first")
     @test_throws err convert(Samples{Matrix{Int32}}, samples)

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -244,7 +244,8 @@ end
     # implicitly, and changing the encoding parameters seems like too big of a change.
     # Therefore, validation errors.
     samples = Samples(rand(sample_type(info), 3, 100), info, true)
-    @test_throws "encoded `data` matrix eltype does not match `sample_type(info)`" convert(Samples{Matrix{Int32}}, samples)
+    err = ArgumentError("encoded `data` matrix eltype does not match `sample_type(info)`")
+    @test_throws err convert(Samples{Matrix{Int32}}, samples)
 end
 
 @testset "Base.copy" begin

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -212,6 +212,41 @@ Base.read(p::BufferPath) = take!(p.io)
     @test samples == loaded_samples
 end
 
+@testset "Base.convert" begin
+    info = SamplesInfoV2(sensor_type="eeg",
+                         channels=["a", "b", "c"],
+                         sample_unit="unit",
+                         sample_resolution_in_unit=1.0,
+                         sample_offset_in_unit=0.0,
+                         sample_type=Int16,
+                         sample_rate=100.0)
+    # We can convert unencoded samples, since there is no constraint between the eltype of the
+    # data and the sample type
+    samples = Samples(rand(Float32, 3, 100), info, false)
+
+    s2 = convert(Samples{Matrix{Float64}}, samples)
+    @test s2.data ≈ samples.data
+    @test s2.info == samples.info
+    @test eltype(s2.data) == Float64
+    @test s2.data isa Matrix{Float64}
+
+    # In particular, this fixes an arrow deserialization issue
+    # (https://github.com/beacon-biosignals/Onda.jl/issues/156)
+    table = [(; col = samples), (; col = samples)]
+    # Here, materializing this table in this way threw an error before `convert` was defined
+    rt_table = DataFrame(Arrow.Table(Arrow.tobuffer(table)); copycols=true)
+    rt = rt_table[1, "col"]
+    @test rt.data isa AbstractMatrix{Float32}
+    @test rt == samples
+
+    # For encoded samples, in generally we cannot `convert`.
+    # We choose to not update encoding parameter in `convert`, since `convert` can be implied
+    # implicitly, and changing the encoding parameters seems like too big of a change.
+    # Therefore, validation errors.
+    samples = Samples(rand(sample_type(info), 3, 100), info, true)
+    @test_throws "encoded `data` matrix eltype does not match `sample_type(info)`" convert(Samples{Matrix{Int32}}, samples)
+end
+
 @testset "Base.copy" begin
     info = SamplesInfoV2(sensor_type="eeg",
                          channels=["a", "b", "c"],


### PR DESCRIPTION
closes #156 

I chose not to update the encoding parameters when converting encoded samples, since that seemed like a change we don't want to make implicitly.