### PR TITLE
Allow `convert`ing encoded samples if the element type matches

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.8"
+version = "0.15.9"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/samples.jl
+++ b/src/samples.jl
@@ -81,7 +81,11 @@ function Base.hash(a::Samples, h::UInt)
 end
 
 function Base.convert(::Type{Samples{T}}, samples::Samples) where {T}
-    samples.encoded && throw(ArgumentError("can't `convert` encoded samples; use `decode` first"))
+    # For encoded samples, allow converting between container types so long as the element
+    # type remains the same
+    if samples.encoded && eltype(T) != eltype(samples.data)
+        throw(ArgumentError("can't `convert` encoded samples to a different element type; use `decode` first"))
+    end
     return Samples(convert(T, samples.data), samples.info, samples.encoded)
 end
 

--- a/test/samples.jl
+++ b/test/samples.jl
@@ -250,9 +250,9 @@ end
     # If the element type remains the same, we can `convert` between container types, as
     # this is unlikely to affect decoding (unless a truly deranged method has been defined)
     T = sample_type(info)
-    samples = Samples(view(rand(T, 3, 100), 1:2, :), info, true)
+    samples = Samples(view(rand(T, 3, 100), :, :), info, true)
     @test samples.data isa SubArray{T}
-    s2 = convert(Samples{Matrix{sample_type(info)}}, samples)
+    s2 = convert(Samples{Matrix{T}}, samples)
     @test s2.data isa Matrix{T}
     @test samples == s2
 end


### PR DESCRIPTION
At present, we error on `convert(::Type{Samples{A}}, ::Samples{B})` for all `A` and `B` if the samples are encoded. This is reasonable since we don't want to affect how the samples get decoded. However, decoding should be based on the type of the encoded samples themselves rather than of their container; a decoder shouldn't care whether the incoming data is e.g. a full matrix or a view of a matrix. Thus we can allow conversion for encoded samples provided that only the container type is affected, not the element type.

cc @rebareh, who ran into this in some private Beacon code.