### PR TITLE
Upgrade Documenter to 1.8 and add missing docstrings

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.10"
+version = "0.15.11"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -3,4 +3,4 @@ Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Onda = "e853f5be-6863-11e9-128d-476edb89bfb5"
 
 [compat]
-Documenter = "0.27"
+Documenter = "1.8"

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -25,6 +25,7 @@ Onda.read_byte_range
 AnnotationV1
 MergedAnnotationV1
 merge_overlapping_annotations
+validate_annotations
 ```
 
 ## `onda.signal`
@@ -38,6 +39,7 @@ channel_count(x)
 sample_count(x, duration::Period)
 sizeof_samples(x, duration::Period)
 sample_type(x)
+validate_signals
 ```
 
 ## `Samples`
@@ -45,6 +47,8 @@ sample_type(x)
 ```@docs
 Samples
 ==(::Samples, ::Samples)
+isequal(::Samples, ::Samples)
+copy(::Samples)
 channel
 channel_count
 sample_count
@@ -59,6 +63,7 @@ channel(samples::Samples, name)
 channel(samples::Samples, i::Integer)
 channel_count(samples::Samples)
 sample_count(samples::Samples)
+Onda.validate_samples
 ```
 
 ## LPCM (De)serialization API


### PR DESCRIPTION
The upgrade also causes what were previously warnings when building docs to now produce errors, which should prevent future docstrings from being missed and references from being broken.