### PR TITLE
Declare documented names as public

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Onda"
 uuid = "e853f5be-6863-11e9-128d-476edb89bfb5"
 authors = ["Beacon Biosignals, Inc."]
-version = "0.15.11"
+version = "0.15.12"
 
 [deps]
 Arrow = "69666777-d1a9-59fb-9406-91d4454c9d45"

--- a/src/Onda.jl
+++ b/src/Onda.jl
@@ -6,6 +6,11 @@ using Compat, Legolas, TimeSpans, Arrow, Tables, TranscodingStreams, CodecZstd
 using Legolas: @schema, @version, write_full_path
 using Tables: rowmerge
 
+if VERSION >= v"1.11.0-DEV.469"
+    eval(Meta.parse("""public read_byte_range, mmap, validate_samples, register_lpcm_format!,
+                       file_format_string, VALIDATE_SAMPLES_DEFAULT, upgrade"""))
+end
+
 include("utilities.jl")
 
 include("annotations.jl")


### PR DESCRIPTION
These are the names that are documented (so considered public) but not exported. Similar to https://github.com/beacon-biosignals/Legolas.jl/pull/136